### PR TITLE
Feature/logger preview check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "prebuild": "eslint . && ./scripts/create_config.sh prod rise-element",

--- a/src/logger-mixin.js
+++ b/src/logger-mixin.js
@@ -19,6 +19,18 @@ export const LoggerMixin = dedupingMixin( base => {
       Object.assign( this.loggerConfig, loggerConfig );
     }
 
+    get LOG_TYPE_INFO() {
+      return "info";
+    }
+
+    get LOG_TYPE_WARNING() {
+      return "warning";
+    }
+
+    get LOG_TYPE_ERROR() {
+      return "error";
+    }
+
     log( type, event, details = null, additionalFields ) {
       if ( RisePlayerConfiguration.isPreview()) {
         return;

--- a/src/logger-mixin.js
+++ b/src/logger-mixin.js
@@ -20,6 +20,10 @@ export const LoggerMixin = dedupingMixin( base => {
     }
 
     log( type, event, details = null, additionalFields ) {
+      if ( RisePlayerConfiguration.isPreview()) {
+        return;
+      }
+
       switch ( type ) {
       case "info":
         RisePlayerConfiguration.Logger.info( this.loggerConfig, event, details, additionalFields );

--- a/src/logger-mixin.js
+++ b/src/logger-mixin.js
@@ -19,15 +19,15 @@ export const LoggerMixin = dedupingMixin( base => {
       Object.assign( this.loggerConfig, loggerConfig );
     }
 
-    get LOG_TYPE_INFO() {
+    static get LOG_TYPE_INFO() {
       return "info";
     }
 
-    get LOG_TYPE_WARNING() {
+    static get LOG_TYPE_WARNING() {
       return "warning";
     }
 
-    get LOG_TYPE_ERROR() {
+    static get LOG_TYPE_ERROR() {
       return "error";
     }
 

--- a/test/unit/logger-mixin.html
+++ b/test/unit/logger-mixin.html
@@ -27,10 +27,10 @@
 <script type="module">
   import * as loggerModule from '../../src/logger-mixin.js';
 
+  const Logger = loggerModule.LoggerMixin(class {});
   let logger;
 
   setup(()=>{
-    let Logger = loggerModule.LoggerMixin(class {});
     logger = new Logger();
 
     RisePlayerConfiguration.Logger.info = sinon.spy();
@@ -46,9 +46,9 @@
 
     suite( "init", () => {
       test( "should log with defaults", () => {
-        logger.log(logger.LOG_TYPE_INFO);
+        logger.log(Logger.LOG_TYPE_INFO);
 
-        assert.equal( 'info', logger.LOG_TYPE_INFO );
+        assert.equal( 'info', Logger.LOG_TYPE_INFO );
         assert.isTrue( RisePlayerConfiguration.Logger.info.called );
         assert.deepEqual( RisePlayerConfiguration.Logger.info.getCall(0).args[0], {
           name: "logger-mixin",
@@ -64,7 +64,7 @@
           version: "__VERSION__"
         });
 
-        logger.log(logger.LOG_TYPE_INFO);
+        logger.log(Logger.LOG_TYPE_INFO);
 
         assert.isTrue( RisePlayerConfiguration.Logger.info.called );
         assert.deepEqual( RisePlayerConfiguration.Logger.info.getCall(0).args[0], {
@@ -77,13 +77,13 @@
 
     suite( "log", () => {
       test( "should call with correct parameters", () => {
-        logger.log(logger.LOG_TYPE_INFO, "event", "details", "additionalFields");
+        logger.log(Logger.LOG_TYPE_INFO, "event", "details", "additionalFields");
 
         assert.isTrue( RisePlayerConfiguration.Logger.info.calledWith(sinon.match.object, "event", "details", "additionalFields") );
       });
 
       test( "should log info", () => {
-        logger.log(logger.LOG_TYPE_INFO);
+        logger.log(Logger.LOG_TYPE_INFO);
 
         assert.isTrue( RisePlayerConfiguration.Logger.info.called );
         assert.isFalse( RisePlayerConfiguration.Logger.warning.called );
@@ -91,7 +91,7 @@
       });
 
       test( "should log warning", () => {
-        logger.log(logger.LOG_TYPE_WARNING);
+        logger.log(Logger.LOG_TYPE_WARNING);
 
         assert.isFalse( RisePlayerConfiguration.Logger.info.called );
         assert.isTrue( RisePlayerConfiguration.Logger.warning.called );
@@ -99,7 +99,7 @@
       });
 
       test( "should log error", () => {
-        logger.log(logger.LOG_TYPE_ERROR);
+        logger.log(Logger.LOG_TYPE_ERROR);
 
         assert.isFalse( RisePlayerConfiguration.Logger.info.called );
         assert.isFalse( RisePlayerConfiguration.Logger.warning.called );
@@ -116,14 +116,14 @@
 
       test( "should log when not in preview", () => {
         preview = false;
-        logger.log(logger.LOG_TYPE_INFO);
+        logger.log(Logger.LOG_TYPE_INFO);
 
         assert.isTrue(RisePlayerConfiguration.Logger.info.called);
       });
 
       test( "should not log in preview", () => {
         preview = true;
-        logger.log(logger.LOG_TYPE_INFO);
+        logger.log(Logger.LOG_TYPE_INFO);
 
         assert.isFalse(RisePlayerConfiguration.Logger.info.called);
       });

--- a/test/unit/logger-mixin.html
+++ b/test/unit/logger-mixin.html
@@ -16,8 +16,11 @@
 <body>
 
 <script type="text/javascript">
+  let preview = false;
+
   RisePlayerConfiguration = {
-    Logger: {}
+    Logger: {},
+    isPreview: () => preview
   };
 </script>
 
@@ -110,6 +113,19 @@
         assert.isFalse( RisePlayerConfiguration.Logger.error.called );
       });
 
+      test( "should log when not in preview", () => {
+        preview = false;
+        logger.log("info");
+
+        assert.isTrue(RisePlayerConfiguration.Logger.info.called);
+      });
+
+      test( "should not log in preview", () => {
+        preview = true;
+        logger.log("info");
+
+        assert.isFalse(RisePlayerConfiguration.Logger.info.called);
+      });
     });
   });
 </script>

--- a/test/unit/logger-mixin.html
+++ b/test/unit/logger-mixin.html
@@ -46,8 +46,9 @@
 
     suite( "init", () => {
       test( "should log with defaults", () => {
-        logger.log("info");
+        logger.log(logger.LOG_TYPE_INFO);
 
+        assert.equal( 'info', logger.LOG_TYPE_INFO );
         assert.isTrue( RisePlayerConfiguration.Logger.info.called );
         assert.deepEqual( RisePlayerConfiguration.Logger.info.getCall(0).args[0], {
           name: "logger-mixin",
@@ -63,7 +64,7 @@
           version: "__VERSION__"
         });
 
-        logger.log("info");
+        logger.log(logger.LOG_TYPE_INFO);
 
         assert.isTrue( RisePlayerConfiguration.Logger.info.called );
         assert.deepEqual( RisePlayerConfiguration.Logger.info.getCall(0).args[0], {
@@ -76,13 +77,13 @@
 
     suite( "log", () => {
       test( "should call with correct parameters", () => {
-        logger.log("info", "event", "details", "additionalFields");
+        logger.log(logger.LOG_TYPE_INFO, "event", "details", "additionalFields");
 
         assert.isTrue( RisePlayerConfiguration.Logger.info.calledWith(sinon.match.object, "event", "details", "additionalFields") );
       });
 
       test( "should log info", () => {
-        logger.log("info");
+        logger.log(logger.LOG_TYPE_INFO);
 
         assert.isTrue( RisePlayerConfiguration.Logger.info.called );
         assert.isFalse( RisePlayerConfiguration.Logger.warning.called );
@@ -90,7 +91,7 @@
       });
 
       test( "should log warning", () => {
-        logger.log("warning");
+        logger.log(logger.LOG_TYPE_WARNING);
 
         assert.isFalse( RisePlayerConfiguration.Logger.info.called );
         assert.isTrue( RisePlayerConfiguration.Logger.warning.called );
@@ -98,7 +99,7 @@
       });
 
       test( "should log error", () => {
-        logger.log("error");
+        logger.log(logger.LOG_TYPE_ERROR);
 
         assert.isFalse( RisePlayerConfiguration.Logger.info.called );
         assert.isFalse( RisePlayerConfiguration.Logger.warning.called );
@@ -115,14 +116,14 @@
 
       test( "should log when not in preview", () => {
         preview = false;
-        logger.log("info");
+        logger.log(logger.LOG_TYPE_INFO);
 
         assert.isTrue(RisePlayerConfiguration.Logger.info.called);
       });
 
       test( "should not log in preview", () => {
         preview = true;
-        logger.log("info");
+        logger.log(logger.LOG_TYPE_INFO);
 
         assert.isFalse(RisePlayerConfiguration.Logger.info.called);
       });


### PR DESCRIPTION
- Move LOG_TYPE_* constants from rise-video / image to prevent duplication
- Move isPreview check from the _log function in rise-video to prevent duplication
- Addition of some new unit tests
- Modification of some unit tests to use new constants rather than hardcoded string values

For the time being (until we return to rise-image after the rise-video epic), rise-image will override the constant in its RiseCommonComponent superclass and the isPreview check will be duplicated, but I don't think this should cause any problems.