### PR TITLE
Feature/abstract file validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "prebuild": "eslint . && ./scripts/create_config.sh prod rise-element",

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -75,7 +75,7 @@ export const ValidFilesMixin = dedupingMixin( base => {
         return { validFiles: files, invalidFiles: [] };
       }
 
-      return this.filterInvalidFileTypes( files.split( "|", validTypes ));
+      return this.filterInvalidFileTypes( files.split( "|" ), validTypes );
     }
   }
 

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -40,16 +40,15 @@ export const ValidFilesMixin = dedupingMixin( base => {
     }
 
     isValidFiles( files ) {
-      if ( !files || typeof files !== "string" ) {
+      if ( !files || !Array.isArray( files )) {
         return false;
       }
 
-      // single symbol
-      if ( files.indexOf( "|" ) === -1 ) {
-        return true;
+      if ( files.filter( f => !f ).length > 0 ) {
+        return false;
       }
 
-      return files.split( "|" ).indexOf( "" ) === -1;
+      return files.length > 0 && files.indexOf( "" ) === -1;
     }
 
     filterInvalidFileTypes( files, validTypes ) {
@@ -80,7 +79,7 @@ export const ValidFilesMixin = dedupingMixin( base => {
         return { validFiles: files, invalidFiles: [] };
       }
 
-      return this.filterInvalidFileTypes( files.split( "|" ), validTypes );
+      return this.filterInvalidFileTypes( files, validTypes );
     }
   }
 

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -1,4 +1,5 @@
 import { dedupingMixin } from "@polymer/polymer/lib/utils/mixin.js";
+import { LoggerMixin } from "./logger-mixin";
 
 export const ValidFilesMixin = dedupingMixin( base => {
   const VALID_FILES_CONFIG = {
@@ -7,7 +8,7 @@ export const ValidFilesMixin = dedupingMixin( base => {
     version: "1.0"
   };
 
-  class ValidFiles extends base {
+  class ValidFiles extends LoggerMixin( base ) {
     constructor() {
       super();
 
@@ -61,6 +62,10 @@ export const ValidFilesMixin = dedupingMixin( base => {
         }
 
         return valid;
+      });
+
+      invalidFiles.forEach( invalidFile => {
+        this.log( ValidFiles.LOG_TYPE_ERROR, "format-invalid", null, { file: invalidFile });
       });
 
       return { validFiles, invalidFiles };

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -64,7 +64,7 @@ export const ValidFilesMixin = dedupingMixin( base => {
       });
 
       invalidFiles.forEach( invalidFile => {
-        this.log( ValidFiles.LOG_TYPE_ERROR, "format-invalid", null, { file: invalidFile });
+        this.log( ValidFiles.LOG_TYPE_ERROR, "format-invalid", null, { file_path: invalidFile });
       });
 
       return { validFiles, invalidFiles };

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -19,7 +19,7 @@ export const ValidFilesMixin = dedupingMixin( base => {
       Object.assign( this.validFilesConfig, validFilesConfig );
     }
 
-    getStorageFileFormat( filePath ) {
+    _getStorageFileFormat( filePath ) {
       if ( !filePath || typeof filePath !== "string" ) {
         return "";
       }
@@ -27,8 +27,8 @@ export const ValidFilesMixin = dedupingMixin( base => {
       return filePath.substr( filePath.lastIndexOf( "." ) + 1 ).toLowerCase();
     }
 
-    isValidFileType( path, validTypes ) {
-      const format = this.getStorageFileFormat( path );
+    _isValidFileType( path, validTypes ) {
+      const format = this._getStorageFileFormat( path );
 
       for ( let i = 0, len = validTypes.length; i < len; i++ ) {
         if ( format.indexOf( validTypes[ i ]) !== -1 ) {
@@ -39,7 +39,7 @@ export const ValidFilesMixin = dedupingMixin( base => {
       return false;
     }
 
-    isValidFiles( files ) {
+    _isValidFiles( files ) {
       if ( !files || !Array.isArray( files )) {
         return false;
       }
@@ -51,10 +51,10 @@ export const ValidFilesMixin = dedupingMixin( base => {
       return files.length > 0 && files.indexOf( "" ) === -1;
     }
 
-    filterInvalidFileTypes( files, validTypes ) {
+    _filterInvalidFileTypes( files, validTypes ) {
       let invalidFiles = [];
       const validFiles = files.filter( file => {
-        const valid = this.isValidFileType( file, validTypes );
+        const valid = this._isValidFileType( file, validTypes );
 
         if ( !valid ) {
           invalidFiles.push( file );
@@ -71,7 +71,7 @@ export const ValidFilesMixin = dedupingMixin( base => {
     }
 
     validateFiles( files, validTypes ) {
-      if ( !this.isValidFiles( files )) {
+      if ( !this._isValidFiles( files )) {
         return { validFiles: [], invalidFiles: [] };
       }
 
@@ -79,7 +79,7 @@ export const ValidFilesMixin = dedupingMixin( base => {
         return { validFiles: files, invalidFiles: [] };
       }
 
-      return this.filterInvalidFileTypes( files, validTypes );
+      return this._filterInvalidFileTypes( files, validTypes );
     }
   }
 

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -51,10 +51,10 @@ export const ValidFilesMixin = dedupingMixin( base => {
       return files.split( "|" ).indexOf( "" ) === -1;
     }
 
-    filterInvalidFileTypes( files ) {
+    filterInvalidFileTypes( files, validTypes ) {
       let invalidFiles = [];
       const validFiles = files.filter( file => {
-        const valid = this.isValidFileType( file );
+        const valid = this.isValidFileType( file, validTypes );
 
         if ( !valid ) {
           invalidFiles.push( file );
@@ -66,12 +66,16 @@ export const ValidFilesMixin = dedupingMixin( base => {
       return { validFiles, invalidFiles };
     }
 
-    validateFiles( files ) {
+    validateFiles( files, validTypes ) {
       if ( !this.isValidFiles( files )) {
         return { validFiles: [], invalidFiles: [] };
       }
 
-      return this.filterInvalidFileTypes( files.split( "|" ));
+      if ( !validTypes || !validTypes.length ) {
+        return { validFiles: files, invalidFiles: [] };
+      }
+
+      return this.filterInvalidFileTypes( files.split( "|", validTypes ));
     }
   }
 

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -74,8 +74,6 @@ export const ValidFilesMixin = dedupingMixin( base => {
         });
       });
 
-      // { storage: this._getStorageData( invalidFile ) });
-
       return { validFiles, invalidFiles };
     }
 

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -64,8 +64,17 @@ export const ValidFilesMixin = dedupingMixin( base => {
       });
 
       invalidFiles.forEach( invalidFile => {
-        this.log( ValidFiles.LOG_TYPE_ERROR, "format-invalid", null, { file_path: invalidFile });
+        this.log( ValidFiles.LOG_TYPE_ERROR, "format-invalid", null, {
+          storage: {
+            configuration: "storage file",
+            file_form: this._getStorageFileFormat( invalidFile ),
+            file_path: invalidFile,
+            local_url: ""
+          }
+        });
       });
+
+      // { storage: this._getStorageData( invalidFile ) });
 
       return { validFiles, invalidFiles };
     }

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -1,0 +1,79 @@
+import { dedupingMixin } from "@polymer/polymer/lib/utils/mixin.js";
+
+export const ValidFilesMixin = dedupingMixin( base => {
+  const VALID_FILES_CONFIG = {
+    name: "valid-files-mixin",
+    id: "valid-files",
+    version: "1.0"
+  };
+
+  class ValidFiles extends base {
+    constructor() {
+      super();
+
+      this.validFilesConfig = Object.assign({}, VALID_FILES_CONFIG );
+    }
+
+    initValidFiles( validFilesConfig ) {
+      Object.assign( this.validFilesConfig, validFilesConfig );
+    }
+
+    getStorageFileFormat( filePath ) {
+      if ( !filePath || typeof filePath !== "string" ) {
+        return "";
+      }
+
+      return filePath.substr( filePath.lastIndexOf( "." ) + 1 ).toLowerCase();
+    }
+
+    isValidFileType( path, validTypes ) {
+      const format = this.getStorageFileFormat( path );
+
+      for ( let i = 0, len = validTypes.length; i < len; i++ ) {
+        if ( format.indexOf( validTypes[ i ]) !== -1 ) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    isValidFiles( files ) {
+      if ( !files || typeof files !== "string" ) {
+        return false;
+      }
+
+      // single symbol
+      if ( files.indexOf( "|" ) === -1 ) {
+        return true;
+      }
+
+      return files.split( "|" ).indexOf( "" ) === -1;
+    }
+
+    filterInvalidFileTypes( files ) {
+      let invalidFiles = [];
+      const validFiles = files.filter( file => {
+        const valid = this.isValidFileType( file );
+
+        if ( !valid ) {
+          invalidFiles.push( file );
+        }
+
+        return valid;
+      });
+
+      return { validFiles, invalidFiles };
+    }
+
+    validateFiles( files ) {
+      if ( !this.isValidFiles( files )) {
+        return { validFiles: [], invalidFiles: [] };
+      }
+
+      return this.filterInvalidFileTypes( files.split( "|" ));
+    }
+  }
+
+  return ValidFiles;
+})

--- a/test/index.html
+++ b/test/index.html
@@ -17,6 +17,7 @@
     "unit/logger-mixin.html",
     "unit/cache-mixin.html",
     "unit/fetch-mixin.html",
+    "unit/valid-files-mixin.html",
   ] );
 </script>
 </body>

--- a/test/unit/valid-files-mixin.html
+++ b/test/unit/valid-files-mixin.html
@@ -50,26 +50,26 @@
       });
     });
 
-    suite( "isValidFiles", () => {
+    suite( "_isValidFiles", () => {
       test( "should return true if 'files' attribute is a non-empty Array", () => {
-        assert.isTrue( validFiles.isValidFiles( [ "test", "test2" ] ) );
+        assert.isTrue( validFiles._isValidFiles( [ "test", "test2" ] ) );
       } );
 
       test( "should return false if 'files' is not a non-empty Array", () => {
-        assert.isFalse( validFiles.isValidFiles( 123 ) );
-        assert.isFalse( validFiles.isValidFiles( "test1" ) );
-        assert.isFalse( validFiles.isValidFiles( [] ) );
+        assert.isFalse( validFiles._isValidFiles( 123 ) );
+        assert.isFalse( validFiles._isValidFiles( "test1" ) );
+        assert.isFalse( validFiles._isValidFiles( [] ) );
       } );
 
       test( "should return false if 'files' contains any empty entries", () => {
-        assert.isFalse( validFiles.isValidFiles( [ "test1", undefined ] ) );
-        assert.isFalse( validFiles.isValidFiles( [ "", "test1" ] ) );
-        assert.isFalse( validFiles.isValidFiles( [ null ] ) );
-        assert.isFalse( validFiles.isValidFiles( [ "test1", "test2", "", "test3" ] ) );
+        assert.isFalse( validFiles._isValidFiles( [ "test1", undefined ] ) );
+        assert.isFalse( validFiles._isValidFiles( [ "", "test1" ] ) );
+        assert.isFalse( validFiles._isValidFiles( [ null ] ) );
+        assert.isFalse( validFiles._isValidFiles( [ "test1", "test2", "", "test3" ] ) );
       } );
     } );
 
-    suite( "filterInvalidFileTypes", () => {
+    suite( "_filterInvalidFileTypes", () => {
       const imageFileTypes = [ "jpg", "jpeg", "png", "bmp", "svg", "gif", "webp" ];
 
       setup( () => {
@@ -83,21 +83,21 @@
       } );
 
       test( "should return filtered files list", () => {
-        assert.deepEqual( validFiles.filterInvalidFileTypes( [ "test1.jpg", "test2.gif", "test3.txt", "test4.png", "test5.webm" ], imageFileTypes ), {
+        assert.deepEqual( validFiles._filterInvalidFileTypes( [ "test1.jpg", "test2.gif", "test3.txt", "test4.png", "test5.webm" ], imageFileTypes ), {
           validFiles: [ "test1.jpg", "test2.gif", "test4.png" ],
           invalidFiles: [ "test3.txt", "test5.webm" ]
         } )
       } );
 
       test( "should return empty list of valid files", () => {
-        assert.deepEqual( validFiles.filterInvalidFileTypes( [ "test1.webm", "test2.text", "test3.mov" ], imageFileTypes ), {
+        assert.deepEqual( validFiles._filterInvalidFileTypes( [ "test1.webm", "test2.text", "test3.mov" ], imageFileTypes ), {
           validFiles: [],
           invalidFiles: [ "test1.webm", "test2.text", "test3.mov" ]
         } );
       } );
 
       test( "should log a 'format-invalid' error for each invalid file", () => {
-        validFiles.filterInvalidFileTypes( [ "test1.jpg", "test2.jpg", "test3.png"], [ "png"] );
+        validFiles._filterInvalidFileTypes( [ "test1.jpg", "test2.jpg", "test3.png"], [ "png"] );
 
         assert.equal( RisePlayerConfiguration.Logger.error.callCount, 2 );
         assert.equal( RisePlayerConfiguration.Logger.error.getCall(0).args[1], "format-invalid" );

--- a/test/unit/valid-files-mixin.html
+++ b/test/unit/valid-files-mixin.html
@@ -102,8 +102,8 @@
         assert.equal( RisePlayerConfiguration.Logger.error.callCount, 2 );
         assert.equal( RisePlayerConfiguration.Logger.error.getCall(0).args[1], "format-invalid" );
         assert.equal( RisePlayerConfiguration.Logger.error.getCall(1).args[1], "format-invalid" );
-        assert.deepEqual( RisePlayerConfiguration.Logger.error.getCall(0).args[3], { file: "test1.jpg" });
-        assert.deepEqual( RisePlayerConfiguration.Logger.error.getCall(1).args[3], { file: "test2.jpg" });
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.getCall(0).args[3], { file_path: "test1.jpg" });
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.getCall(1).args[3], { file_path: "test2.jpg" });
       } )
     } );
   });

--- a/test/unit/valid-files-mixin.html
+++ b/test/unit/valid-files-mixin.html
@@ -102,8 +102,24 @@
         assert.equal( RisePlayerConfiguration.Logger.error.callCount, 2 );
         assert.equal( RisePlayerConfiguration.Logger.error.getCall(0).args[1], "format-invalid" );
         assert.equal( RisePlayerConfiguration.Logger.error.getCall(1).args[1], "format-invalid" );
-        assert.deepEqual( RisePlayerConfiguration.Logger.error.getCall(0).args[3], { file_path: "test1.jpg" });
-        assert.deepEqual( RisePlayerConfiguration.Logger.error.getCall(1).args[3], { file_path: "test2.jpg" });
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.getCall(0).args[3], {
+          storage: {
+            configuration: "storage file",
+            file_form: "jpg",
+            local_url: "",
+            file_path: "test1.jpg",
+            local_url: ""
+          }
+        });
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.getCall(1).args[3], {
+          storage: {
+            configuration: "storage file",
+            file_form: "jpg",
+            local_url: "",
+            file_path: "test2.jpg",
+            local_url: ""
+          }
+        });
       } )
     } );
   });

--- a/test/unit/valid-files-mixin.html
+++ b/test/unit/valid-files-mixin.html
@@ -76,15 +76,15 @@
     suite( "filterInvalidFileTypes", () => {
       const imageFileTypes = [ "jpg", "jpeg", "png", "bmp", "svg", "gif", "webp" ];
 
-      setup(()=>{
+      setup( () => {
         RisePlayerConfiguration.Logger.info = sinon.spy();
         RisePlayerConfiguration.Logger.warning = sinon.spy();
         RisePlayerConfiguration.Logger.error = sinon.spy();
-      });
+      } );
 
-      teardown(()=>{
+      teardown( () => {
         RisePlayerConfiguration.Logger = {};
-      });
+      } );
 
       test( "should return filtered files list", () => {
         assert.deepEqual( validFiles.filterInvalidFileTypes( [ "test1.jpg", "test2.gif", "test3.txt", "test4.png", "test5.webm" ], imageFileTypes ), {

--- a/test/unit/valid-files-mixin.html
+++ b/test/unit/valid-files-mixin.html
@@ -10,7 +10,7 @@
   <script src="../../node_modules/mocha/mocha.js"></script>
   <script src="../../node_modules/chai/chai.js"></script>
   <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
-
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
 </head>
 <body>
 
@@ -76,6 +76,16 @@
     suite( "filterInvalidFileTypes", () => {
       const imageFileTypes = [ "jpg", "jpeg", "png", "bmp", "svg", "gif", "webp" ];
 
+      setup(()=>{
+        RisePlayerConfiguration.Logger.info = sinon.spy();
+        RisePlayerConfiguration.Logger.warning = sinon.spy();
+        RisePlayerConfiguration.Logger.error = sinon.spy();
+      });
+
+      teardown(()=>{
+        RisePlayerConfiguration.Logger = {};
+      });
+
       test( "should return filtered files list", () => {
         assert.deepEqual( validFiles.filterInvalidFileTypes( [ "test1.jpg", "test2.gif", "test3.txt", "test4.png", "test5.webm" ], imageFileTypes ), {
           validFiles: [ "test1.jpg", "test2.gif", "test4.png" ],
@@ -89,6 +99,16 @@
           invalidFiles: [ "test1.webm", "test2.text", "test3.mov" ]
         } );
       } );
+
+      test( "should log a 'format-invalid' error for each invalid file", () => {
+        validFiles.filterInvalidFileTypes( [ "test1.jpg", "test2.jpg", "test3.png"], [ "png"] );
+
+        assert.equal( RisePlayerConfiguration.Logger.error.callCount, 2 );
+        assert.equal( RisePlayerConfiguration.Logger.error.getCall(0).args[1], "format-invalid" );
+        assert.equal( RisePlayerConfiguration.Logger.error.getCall(1).args[1], "format-invalid" );
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.getCall(0).args[3], { file: "test1.jpg" });
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.getCall(1).args[3], { file: "test2.jpg" });
+      } )
     } );
   });
 </script>

--- a/test/unit/valid-files-mixin.html
+++ b/test/unit/valid-files-mixin.html
@@ -1,0 +1,57 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script src="../../node_modules/chai/chai.js"></script>
+  <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+
+</head>
+<body>
+
+<script type="text/javascript">
+  RisePlayerConfiguration = {
+    Logger: {},
+    isPreview: () => false
+  };
+</script>
+
+<script type="module">
+  import * as validFilesModule from '../../src/valid-files-mixin.js';
+
+  const ValidFiles = validFilesModule.ValidFilesMixin(class {});
+  let validFiles;
+
+  setup(()=>{
+    validFiles = new ValidFiles();
+  });
+
+  suite("valid files", () => {
+
+    suite( "init", () => {
+      test( "should init validFiles", () => {
+        const validFilesConfig = {
+          name: "rise-common-component",
+          id: "elementId",
+          version: "__VERSION__"
+        };
+
+        validFiles.initValidFiles( validFilesConfig) ;
+
+        assert.deepEqual( validFiles.validFilesConfig, {
+          name: "rise-common-component",
+          id: "elementId",
+          version: "__VERSION__"
+        });
+      });
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/test/unit/valid-files-mixin.html
+++ b/test/unit/valid-files-mixin.html
@@ -51,25 +51,21 @@
     });
 
     suite( "isValidFiles", () => {
-      test( "should return true if 'files' attribute is a non-empty String", () => {
-        assert.isTrue( validFiles.isValidFiles( "test" ) );
+      test( "should return true if 'files' attribute is a non-empty Array", () => {
+        assert.isTrue( validFiles.isValidFiles( [ "test", "test2" ] ) );
       } );
 
-      test( "should return false if 'files' is not a String or empty String", () => {
+      test( "should return false if 'files' is not a non-empty Array", () => {
         assert.isFalse( validFiles.isValidFiles( 123 ) );
-        assert.isFalse( validFiles.isValidFiles( ["test1|test2"] ) );
-        assert.isFalse( validFiles.isValidFiles( "" ) );
+        assert.isFalse( validFiles.isValidFiles( "test1" ) );
+        assert.isFalse( validFiles.isValidFiles( [] ) );
       } );
 
-      test( "should return true if 'files' is a String containing values separated by '|'", () => {
-        assert.isTrue( validFiles.isValidFiles( "test1|test2|test3" ) );
-      } );
-
-      test( "should return false if 'files' contains '|' with any empty value", () => {
-        assert.isFalse( validFiles.isValidFiles( "test|" ) );
-        assert.isFalse( validFiles.isValidFiles( "|test" ) );
-        assert.isFalse( validFiles.isValidFiles( "|" ) );
-        assert.isFalse( validFiles.isValidFiles( "test1|test2||test3" ) );
+      test( "should return false if 'files' contains any empty entries", () => {
+        assert.isFalse( validFiles.isValidFiles( [ "test1", undefined ] ) );
+        assert.isFalse( validFiles.isValidFiles( [ "", "test1" ] ) );
+        assert.isFalse( validFiles.isValidFiles( [ null ] ) );
+        assert.isFalse( validFiles.isValidFiles( [ "test1", "test2", "", "test3" ] ) );
       } );
     } );
 

--- a/test/unit/valid-files-mixin.html
+++ b/test/unit/valid-files-mixin.html
@@ -32,7 +32,6 @@
   });
 
   suite("valid files", () => {
-
     suite( "init", () => {
       test( "should init validFiles", () => {
         const validFilesConfig = {
@@ -50,6 +49,47 @@
         });
       });
     });
+
+    suite( "isValidFiles", () => {
+      test( "should return true if 'files' attribute is a non-empty String", () => {
+        assert.isTrue( validFiles.isValidFiles( "test" ) );
+      } );
+
+      test( "should return false if 'files' is not a String or empty String", () => {
+        assert.isFalse( validFiles.isValidFiles( 123 ) );
+        assert.isFalse( validFiles.isValidFiles( ["test1|test2"] ) );
+        assert.isFalse( validFiles.isValidFiles( "" ) );
+      } );
+
+      test( "should return true if 'files' is a String containing values separated by '|'", () => {
+        assert.isTrue( validFiles.isValidFiles( "test1|test2|test3" ) );
+      } );
+
+      test( "should return false if 'files' contains '|' with any empty value", () => {
+        assert.isFalse( validFiles.isValidFiles( "test|" ) );
+        assert.isFalse( validFiles.isValidFiles( "|test" ) );
+        assert.isFalse( validFiles.isValidFiles( "|" ) );
+        assert.isFalse( validFiles.isValidFiles( "test1|test2||test3" ) );
+      } );
+    } );
+
+    suite( "filterInvalidFileTypes", () => {
+      const imageFileTypes = [ "jpg", "jpeg", "png", "bmp", "svg", "gif", "webp" ];
+
+      test( "should return filtered files list", () => {
+        assert.deepEqual( validFiles.filterInvalidFileTypes( [ "test1.jpg", "test2.gif", "test3.txt", "test4.png", "test5.webm" ], imageFileTypes ), {
+          validFiles: [ "test1.jpg", "test2.gif", "test4.png" ],
+          invalidFiles: [ "test3.txt", "test5.webm" ]
+        } )
+      } );
+
+      test( "should return empty list of valid files", () => {
+        assert.deepEqual( validFiles.filterInvalidFileTypes( [ "test1.webm", "test2.text", "test3.mov" ], imageFileTypes ), {
+          validFiles: [],
+          invalidFiles: [ "test1.webm", "test2.text", "test3.mov" ]
+        } );
+      } );
+    } );
   });
 </script>
 


### PR DESCRIPTION
Port the file validation logic from `rise-image` into a reusable mixin that can be used by rise-video and eventually rise-image and other components.

As the changes are isolated to a mixin that is only currently used by `rise-video`, there shouldn't be any risk here.

For an example of usage you can see this `rise-video` [feature branch](https://github.com/Rise-Vision/rise-video/compare/feature/handle-invalid-filenames)

Notable changes:

1) All methods now operate on arrays of files, instead of pipe-separated strings
2) `filterInvalidFileTypes`, `validateFiles` and `isValidFileType` now accept a list of valid file types
3) `filterInvalidFileTypes` and `validateFiles` now return an object containing the valid / invalid files instead of an array of valid files, which prevents having to manually determine which files were valid / invalid
4) The mixin now handles logging `format-invalid` events, so components shouldn't have to log `image-format-invalid` or `video-format-invalid` events. I've only included a single key (`{file: "filename"}`) whereas `rise-image` included something like the following with its `image-format-invalid` errors:

```
{
      configuration: "storage file",
      file_form: "png",
      file_path: "test.png",
      local_url: ""
}
```

Is just including the `file_path` ok here, or do we need these other fields as well?