### PR TITLE
Feature/abstract file watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "prebuild": "eslint . && ./scripts/create_config.sh prod rise-element",

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -2,7 +2,6 @@
 
 import { dedupingMixin } from "@polymer/polymer/lib/utils/mixin.js";
 import { LoggerMixin } from "./logger-mixin";
-import { RiseElementMixin } from "./rise-element";
 
 export const WatchFilesMixin = dedupingMixin( base => {
   const WATCH_FILES_CONFIG = {
@@ -11,7 +10,7 @@ export const WatchFilesMixin = dedupingMixin( base => {
     version: "1.0"
   };
 
-  class WatchFiles extends LoggerMixin( RiseElementMixin( base )) {
+  class WatchFiles extends LoggerMixin( base ) {
     constructor() {
       super();
 

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -1,0 +1,25 @@
+import { dedupingMixin } from "@polymer/polymer/lib/utils/mixin.js";
+import { LoggerMixin } from "./logger-mixin";
+
+export const WatchFilesMixin = dedupingMixin( base => {
+  const WATCH_FILES_CONFIG = {
+    name: "watch-files-mixin",
+    id: "valid-files",
+    version: "1.0"
+  };
+
+  class WatchFiles extends LoggerMixin( base ) {
+    constructor() {
+      super();
+
+      this.watchFilesConfig = Object.assign({}, WATCH_FILES_CONFIG );
+    }
+
+    initWatchFiles( watchFilesConfig ) {
+      Object.assign( this.watchFilesConfig, watchFilesConfig );
+    }
+
+  }
+
+  return WatchFiles;
+})

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -150,7 +150,7 @@ export const WatchFilesMixin = dedupingMixin( base => {
         "Invalid response with status code [CODE]"
        */
 
-      this.log( WatchFiles.LOG_TYPE_ERROR, "image-rls-error", {
+      this.log( WatchFiles.LOG_TYPE_ERROR, "file-rls-error", {
         errorMessage: message.errorMessage,
         errorDetail: message.errorDetail
       }, {

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-console, one-var */
-
 import { dedupingMixin } from "@polymer/polymer/lib/utils/mixin.js";
 import { LoggerMixin } from "./logger-mixin";
 
@@ -26,17 +24,11 @@ export const WatchFilesMixin = dedupingMixin( base => {
       Object.assign( this.watchFilesConfig, watchFilesConfig );
     }
 
-    watchedFileAddedCallback( details ) {
-      console.log( "watched file added", details );
-    }
+    watchedFileAddedCallback() {}
 
-    watchedFileDeletedCallback( details ) {
-      console.log( "watched file deleted", details );
-    }
+    watchedFileDeletedCallback() {}
 
-    watchedFileErrorCallback( details ) {
-      console.log( "watched file error", details );
-    }
+    watchedFileErrorCallback() {}
 
     _getStorageFileFormat( filePath ) {
       if ( !filePath || typeof filePath !== "string" ) {

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -13,12 +13,174 @@ export const WatchFilesMixin = dedupingMixin( base => {
       super();
 
       this.watchFilesConfig = Object.assign({}, WATCH_FILES_CONFIG );
+      this.managedFiles = [];
+
+      this._watchInitiated = false;
+      this._managedFilesInError = [];
     }
+
+    // TODO: Error name constants
 
     initWatchFiles( watchFilesConfig ) {
       Object.assign( this.watchFilesConfig, watchFilesConfig );
     }
 
+    _getStorageFileFormat( filePath ) {
+      if ( !filePath || typeof filePath !== "string" ) {
+        return "";
+      }
+
+      return filePath.substr( filePath.lastIndexOf( "." ) + 1 ).toLowerCase();
+    }
+
+    _manageFileInError( details, fixed ) {
+      const { filePath, params } = details;
+
+      if ( !filePath ) {
+        return;
+      }
+
+      let fileInError = this._getManagedFileInError( filePath );
+
+      if ( fixed && fileInError ) {
+        // remove this file from files in error list
+        this._managedFilesInError.splice( this._managedFilesInError.findIndex( file => file.filePath === filePath ), 1 );
+      } else if ( !fixed ) {
+        if ( !fileInError ) {
+          fileInError = { filePath, params };
+          // add this file to list of files in error
+          this._managedFilesInError.push( fileInError );
+        } else {
+          fileInError.params = params;
+        }
+      }
+    }
+
+    _manageFile( message ) {
+      const { filePath, status, fileUrl } = message;
+
+      let managedFile = this.getManagedFile( filePath );
+
+      if ( status.toUpperCase() === "CURRENT" ) {
+        if ( !managedFile ) {
+          // get the order that this file should be in from _filesList
+          const order = this._filesList.findIndex( path => path === filePath );
+
+          managedFile = { filePath, fileUrl, order };
+
+          // add this file to list
+          this.managedFiles.push( managedFile );
+        } else {
+          // file has been updated
+          managedFile.fileUrl = fileUrl;
+        }
+      }
+
+      if ( status.toUpperCase() === "DELETED" && managedFile ) {
+        this.managedFiles.splice( this.managedFiles.findIndex( file => file.filePath === filePath ), 1 );
+      }
+
+      // sort the managed files based on order value
+      this.managedFiles.sort(( a, b ) => a.order - b.order );
+    }
+
+    _getManagedFileInError( filePath ) {
+      return this._managedFilesInError.find( file => file.filePath === filePath );
+    }
+
+    getManagedFile( filePath ) {
+      return this.managedFiles.find( file => file.filePath === filePath );
+    }
+
+    startWatch( filesList ) {
+      if ( !this._watchInitiated ) {
+        filesList.forEach( file => {
+          RisePlayerConfiguration.LocalStorage.watchSingleFile(
+            file, message => this._handleSingleFileUpdate( message )
+          );
+        });
+
+        this._watchInitiated = true;
+      }
+    }
+
+    stopWatch() {
+      this._watchInitiated = false;
+      this.managedFiles = [];
+      this._managedFilesInError = [];
+      this._filesToRenderList = [];
+    }
+
+    _handleSingleFileError( message ) {
+      const { filePath, fileUrl } = message,
+        details = { filePath, errorMessage: message.errorMessage, errorDetail: message.errorDetail },
+        fileInError = this._getManagedFileInError( filePath );
+
+      // prevent repetitive logging when component instance is receiving messages from other potential component instances watching same file
+      // Note: to avoid using Lodash or Underscore library for just a .isEqual() function, taking a simple approach to object comparison with JSON.stringify()
+      // as the property order will not change and the data is not large for this object
+      if ( fileInError && ( JSON.stringify( details ) === JSON.stringify( fileInError.details ))) {
+        return;
+      }
+
+      this._manageFileInError( details, false );
+
+      /*** Possible error messages from Local Storage ***/
+      /*
+        "File's host server could not be reached"
+        "File I/O Error"
+        "Could not retrieve signed URL"
+        "Insufficient disk space"
+        "Invalid response with status code [CODE]"
+       */
+
+      this._log( WatchFiles.LOG_TYPE_ERROR, "image-rls-error", {
+        errorMessage: message.errorMessage,
+        errorDetail: message.errorDetail
+      }, {
+        storage: {
+          configuration: "storage file",
+          file_form: this._getStorageFileFormat( filePath ),
+          file_path: filePath,
+          local_url: fileUrl || ""
+        }
+      });
+
+      if ( this.getManagedFile( filePath )) {
+        // remove this file from the file list since there was a problem with its new version being provided
+        this._manageFile({ filePath, status: "deleted" });
+      }
+
+      super._sendEvent( "watched-file-error", details );
+    }
+
+    _handleSingleFileUpdate( message ) {
+      if ( !message.status || !message.filePath ) {
+        return;
+      }
+
+      if ( message.status.toUpperCase() === "FILE-ERROR" ) {
+        this._handleSingleFileError( message );
+        return;
+      }
+
+      this.handleFileStatusUpdated( message );
+    }
+
+    handleFileStatusUpdated( message ) {
+      const { filePath, status } = message;
+
+      this._manageFile( message );
+      this._manageFileInError( message, true );
+
+      if ( status.toUpperCase() === "DELETED" ) {
+        super._sendEvent( "watched-file-deleted", { filePath });
+      }
+
+      if ( status.toUpperCase() === "CURRENT" ) {
+        super._sendEvent( "watched-file-added", { filePath });
+      }
+    }
   }
 
   return WatchFiles;

--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,7 @@
     "unit/cache-mixin.html",
     "unit/fetch-mixin.html",
     "unit/valid-files-mixin.html",
+    "unit/watch-files-mixin.html"
   ] );
 </script>
 </body>

--- a/test/index.html
+++ b/test/index.html
@@ -13,11 +13,11 @@
 <script>
   /* global WCT */
   WCT.loadSuites( [
-    "unit/rise-element.html",
-    "unit/logger-mixin.html",
-    "unit/cache-mixin.html",
-    "unit/fetch-mixin.html",
-    "unit/valid-files-mixin.html",
+    // "unit/rise-element.html",
+    // "unit/logger-mixin.html",
+    // "unit/cache-mixin.html",
+    // "unit/fetch-mixin.html",
+    // "unit/valid-files-mixin.html",
     "unit/watch-files-mixin.html"
   ] );
 </script>

--- a/test/index.html
+++ b/test/index.html
@@ -13,11 +13,11 @@
 <script>
   /* global WCT */
   WCT.loadSuites( [
-    // "unit/rise-element.html",
-    // "unit/logger-mixin.html",
-    // "unit/cache-mixin.html",
-    // "unit/fetch-mixin.html",
-    // "unit/valid-files-mixin.html",
+    "unit/rise-element.html",
+    "unit/logger-mixin.html",
+    "unit/cache-mixin.html",
+    "unit/fetch-mixin.html",
+    "unit/valid-files-mixin.html",
     "unit/watch-files-mixin.html"
   ] );
 </script>

--- a/test/unit/watch-files-mixin.html
+++ b/test/unit/watch-files-mixin.html
@@ -15,15 +15,21 @@
 <body>
 
 <script type="text/javascript">
-  const SAMPLE_VIDEOS = [
-    "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/example_MP4_1280x720_10MB.mp4"
-  ];
-  const sampleUrl = path => `https://storage.googleapis.com/${ path }`;
+  const sampleUrl = path => `https://storage.googleapis.com/${ path }`; // TODO: Do I need this?
 
   RisePlayerConfiguration = {
-    Logger: {},
+    Logger: {
+      info: sinon.spy(),
+      error: sinon.spy(),
+      warning: sinon.spy()
+    },
     isConfigured: () => true,
-    isPreview: () => false
+    isPreview: () => false,
+    LocalStorage: {
+      watchSingleFile: (file, handler) => {
+        handler({ status: "CURRENT", filePath: file, fileUrl: sampleUrl( file ) });
+      }
+    }
   };
 </script>
 
@@ -37,7 +43,7 @@
     watchFiles = new WatchFiles();
   });
 
-  suite("watch files", () => {
+  suite( "watch files", () => {
     suite( "init", () => {
       test( "should init watchFiles", () => {
         const watchFilesConfig = {
@@ -51,7 +57,133 @@
         assert.deepEqual( watchFiles.watchFilesConfig, watchFilesConfig );
       });
     });
-  });
+
+    suite( "events", () => {
+      setup( () => {
+        sinon.spy( watchFiles, "watchedFileAddedCallback" );
+        sinon.spy( watchFiles, "watchedFileDeletedCallback" );
+        sinon.spy( watchFiles, "watchedFileErrorCallback" );
+      } );
+
+      teardown( () => {
+        watchFiles.watchedFileAddedCallback.restore();
+        watchFiles.watchedFileDeletedCallback.restore();
+        watchFiles.watchedFileErrorCallback.restore();
+      } );
+
+      test( "should handle adding files", () => {
+        watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] );
+
+        assert.equal( watchFiles.watchedFileAddedCallback.callCount, 2 );
+        assert.equal ( watchFiles.managedFiles.length, 2);
+      } );
+
+      test( "should handle file errors", () => {
+        watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] );
+
+        watchFiles._handleSingleFileUpdate( {
+          filePath: "foo.jpg",
+          fileUrl: sampleUrl( "foo.jpg" ),
+          status: "file-error",
+          errorMessage: "Network error",
+          errorDetail: "Detailed network error"
+        } );
+
+        assert.equal( watchFiles.watchedFileErrorCallback.callCount, 1 );
+        assert.equal (watchFiles.managedFiles.length, 1 );
+        assert.equal (watchFiles._managedFilesInError.length, 1 );
+      } );
+
+      test( "should handle deleting files", () => {
+        watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] );
+
+        watchFiles._handleSingleFileUpdate( {
+          filePath: "foo.jpg",
+          fileUrl: sampleUrl( "foo.jpg" ),
+          status: "deleted",
+        } );
+
+        assert.equal( watchFiles.watchedFileDeletedCallback.callCount, 1 );
+        assert.equal( watchFiles.managedFiles.length, 1);
+        assert.equal( watchFiles._managedFilesInError.length, 0);
+      } );
+    } );
+
+    suite( "ordering", () => {
+      setup( () => {
+        sinon.spy( watchFiles, "watchedFileAddedCallback" );
+      } );
+
+      teardown( () => {
+        watchFiles.watchedFileAddedCallback.restore();
+      } );
+
+      test( "should preserve order of files that come in out of order", done => {
+        const delays = {
+          "a.jpg": 50,
+          "b.jpg": 100,
+          "c.jpg": 0
+        };
+        const maxDelay = 100;
+
+        sinon.stub( RisePlayerConfiguration.LocalStorage, "watchSingleFile" ).callsFake( (file, handler) => {
+          setTimeout( () => {
+            handler( { status: "CURRENT", filePath: file, fileUrl: sampleUrl( file ) } );
+          }, delays[file]) ;
+        } );
+
+        watchFiles.startWatch( [ "a.jpg", "b.jpg", "c.jpg" ] );
+
+        setTimeout( () => {
+          const addedCalls = watchFiles.watchedFileAddedCallback.getCalls();
+
+          assert.isTrue( addedCalls[0].calledWithExactly( { filePath: "c.jpg" } ) );
+          assert.isTrue( addedCalls[1].calledWithExactly( { filePath: "a.jpg" } ) );
+          assert.isTrue( addedCalls[2].calledWithExactly( { filePath: "b.jpg" } ) );
+
+          assert.equal( watchFiles.getManagedFile( "a.jpg" ).order, 0);
+          assert.equal( watchFiles.getManagedFile( "b.jpg" ).order, 1);
+          assert.equal( watchFiles.getManagedFile( "c.jpg" ).order, 2);
+
+          RisePlayerConfiguration.LocalStorage.watchSingleFile.restore();
+          done();
+        }, maxDelay );
+      } );
+    } );
+
+    suite( "startWatch", () => {
+      test( "should initialize properties", () => {
+        const files = [ "a.jpg", "b.jpg" ];
+
+        watchFiles.startWatch( files );
+
+        assert.deepEqual( watchFiles._filesList, files );
+        assert.isTrue( watchFiles._watchInitiated );
+        assert.equal( watchFiles.managedFiles.length, 2);
+      } );
+
+      test( "should not reinitialize if watch has already been initiated", () => {
+        let managedFiles;
+
+        watchFiles.startWatch( [ "a.jpg", "b.jpg" ] );
+        managedFiles = watchFiles.managedFiles.slice();
+        watchFiles.startWatch( [ "c.jpg", "d.jpg" ] );
+
+        assert.deepEqual( watchFiles.managedFiles, managedFiles);
+      });
+    } );
+
+    suite( "stopWatch", () => {
+      test( "should reset properties", () => {
+        watchFiles.startWatch( [ "a.jpg", "b.jpg" ] );
+        watchFiles.stopWatch();
+
+        assert.isFalse( watchFiles._watchInitiated );
+        assert.isEmpty( watchFiles.managedFiles );
+        assert.isEmpty( watchFiles._filesList );
+      } );
+    } );
+  } );
 </script>
 
 </body>

--- a/test/unit/watch-files-mixin.html
+++ b/test/unit/watch-files-mixin.html
@@ -1,0 +1,58 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script src="../../node_modules/chai/chai.js"></script>
+  <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+</head>
+<body>
+
+<script type="text/javascript">
+  const SAMPLE_VIDEOS = [
+    "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/example_MP4_1280x720_10MB.mp4"
+  ];
+  const sampleUrl = path => `https://storage.googleapis.com/${ path }`;
+
+  RisePlayerConfiguration = {
+    Logger: {},
+    isConfigured: () => true,
+    isPreview: () => false
+  };
+</script>
+
+<script type="module">
+  import * as watchFilesModule from '../../src/watch-files-mixin.js';
+
+  const WatchFiles = watchFilesModule.WatchFilesMixin(class {});
+  let watchFiles;
+
+  setup(()=>{
+    watchFiles = new WatchFiles();
+  });
+
+  suite("watch files", () => {
+    suite( "init", () => {
+      test( "should init watchFiles", () => {
+        const watchFilesConfig = {
+          name: "rise-common-component",
+          id: "elementId",
+          version: "__VERSION__"
+        };
+
+        watchFiles.initWatchFiles( watchFilesConfig)  ;
+
+        assert.deepEqual( watchFiles.watchFilesConfig, watchFilesConfig );
+      });
+    });
+  });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Port file watch logic from `rise-image` for use in `rise-video` and other components.

Component specific logic can be implemented by overriding callback functions, ie: `watchedFileAddedCallback, watchedFileErrorCallback, watchedFileDeletedCallback`.

For a reference usage, see this [rise-video pull request](https://github.com/Rise-Vision/rise-video/pull/6)