### PR TITLE
Add offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,14 @@ For caching arbitrary data responses, the mixin uses browsers Cache API.
 
 Whenever the cached data is retrieved, the mixin checks the date header and delete it from cache in case it is expired. Also, to prevent cache from growing indefinitely, during mixin initialization all expired cache entries are deleted.
 
-To enable the mixin in your component you have to declare the mixin and call the `initCache` function with your desired cache name and optionally duration. Cache duration defaults to 2h. 
+To enable the mixin in your component you have to declare the mixin and call the `initCache` function with your desired cache name and optionally duration. Cache duration defaults to 2h. By default the mixin removes expired entries; this behavior can be changed with the `preserveExpired` attribute. Default values are:
+```
+{
+  name: "cache-mixin",
+  duration: 1000 * 60 * 60 * 2,
+  preserveExpired: false
+}
+```
 
 To use the `cacheMixin`, there are two functions:
 
@@ -156,7 +163,8 @@ To enable the mixin in your component you have to declare the mixin and call the
   retry: 1000 * 60,
   cooldown: 1000 * 60 * 10,
   refresh: 1000 * 60 * 60,
-  count: 5
+  count: 5,
+  useCacheIfOffline: false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,15 @@ For caching arbitrary data responses, the mixin uses browsers Cache API.
 
 Whenever the cached data is retrieved, the mixin checks the date header and delete it from cache in case it is expired. Also, to prevent cache from growing indefinitely, during mixin initialization all expired cache entries are deleted.
 
-To enable the mixin in your component you have to declare the mixin and call the `initCache` function with your desired cache name and optionally duration. Cache duration defaults to 2h. Cache expiry defaults to 4h. Caches entries are removed using the expiry attribute; if set to -1, entries are not removed. Default values are:
+To enable the mixin in your component you have to declare the mixin and call the `initCache` function with your desired cache name and optionally duration. Cache duration defaults to 2h. Cache expiry defaults to 4h. For greater certainty:
+
+- `duration` is how long a cache entry is valid, after which data will be requested again
+- `expiration` is how long a cache entry is kept for offline, before it gets removed from the cache
+
+Setting any of the timers to -1 ignores that functionality and either hits the API every time (except for offline) or uses the offline version all the time (until it expires).
+
+
+Default values are:
 ```
 {
   name: "cache-mixin",
@@ -100,6 +108,7 @@ To enable the mixin in your component you have to declare the mixin and call the
   expiry: 1000 * 60 * 60 * 2
 }
 ```
+
 
 To use the `cacheMixin`, there are two functions:
 

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ For caching arbitrary data responses, the mixin uses browsers Cache API.
 
 Whenever the cached data is retrieved, the mixin checks the date header and delete it from cache in case it is expired. Also, to prevent cache from growing indefinitely, during mixin initialization all expired cache entries are deleted.
 
-To enable the mixin in your component you have to declare the mixin and call the `initCache` function with your desired cache name and optionally duration. Cache duration defaults to 2h. By default the mixin removes expired entries; this behavior can be changed with the `preserveExpired` attribute. Default values are:
+To enable the mixin in your component you have to declare the mixin and call the `initCache` function with your desired cache name and optionally duration. Cache duration defaults to 2h. Cache expiry defaults to 4h. Caches entries are removed using the expiry attribute; if set to -1, entries are not removed. Default values are:
 ```
 {
   name: "cache-mixin",
   duration: 1000 * 60 * 60 * 2,
-  preserveExpired: false
+  expiry: 1000 * 60 * 60 * 2
 }
 ```
 
@@ -163,8 +163,7 @@ To enable the mixin in your component you have to declare the mixin and call the
   retry: 1000 * 60,
   cooldown: 1000 * 60 * 10,
   refresh: 1000 * 60 * 60,
-  count: 5,
-  useCacheIfOffline: false
+  count: 5
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.0.4",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "prebuild": "eslint . && ./scripts/create_config.sh prod rise-element",

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -5,7 +5,7 @@ export const CacheMixin = dedupingMixin( base => {
   const CACHE_CONFIG = {
       name: "cache-mixin",
       duration: 1000 * 60 * 60 * 2,
-      preserveExpired: false
+      expiry: 1000 * 60 * 60 * 4
     },
     cacheBase = LoggerMixin( base );
 
@@ -19,9 +19,7 @@ export const CacheMixin = dedupingMixin( base => {
     initCache( cacheConfig ) {
       Object.assign( this.cacheConfig, cacheConfig );
 
-      if ( !this.cacheConfig.preserveExpired ) {
-        this._deleteExpiredCache();
-      }
+      this._deleteExpiredCache();
     }
 
     _getCache() {
@@ -34,14 +32,22 @@ export const CacheMixin = dedupingMixin( base => {
       }
     }
 
+    _isResponseExpired( response, expiration ) {
+      if ( expiration === -1 ) {
+        return false;
+      } else {
+        const date = response && response.headers && new Date( response.headers.get( "date" ));
+
+        return !date || ( Date.now() > date.getTime() + expiration );
+      }
+    }
+
     _deleteExpiredCache() {
       this._getCache().then( cache => {
         cache.keys().then( keys => {
           keys.forEach( key => {
             cache.match( key ).then( response => {
-              const date = new Date( response.headers.get( "date" ));
-
-              if ( Date.now() > date.getTime() + this.cacheConfig.duration ) {
+              if ( this._isResponseExpired( response, this.cacheConfig.expiry )) {
                 cache.delete( key );
               }
             });
@@ -51,34 +57,27 @@ export const CacheMixin = dedupingMixin( base => {
     }
 
     putCache( res ) {
-      this._getCache().then( cache => {
+      return this._getCache().then( cache => {
         return cache.put( res.url, res );
       }).catch( err => {
         super.log( "warning", "cache put failed", { url: res.url }, err );
       });
     }
 
-    getCache( url, ignoreExpiration ) {
+    getCache( url ) {
       var _cache;
 
       return this._getCache().then( cache => {
         _cache = cache;
         return cache.match( url );
       }).then( response => {
-        if ( response ) {
-          const date = new Date( response.headers.get( "date" ));
-
-          if ( ignoreExpiration || Date.now() < date.getTime() + this.cacheConfig.duration ) {
-            return Promise.resolve( response );
-
-          } else {
-            if ( !this.cacheConfig.preserveExpired ) {
-              _cache.delete( url );
-            }
-
-            return Promise.reject();
-          }
+        if ( !this._isResponseExpired( response, this.cacheConfig.duration )) {
+          return Promise.resolve( response );
+        } else if ( !this._isResponseExpired( response, this.cacheConfig.expiry )) {
+          return Promise.reject( response );
         } else {
+          response && _cache.delete( url );
+
           return Promise.reject();
         }
       });

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -58,7 +58,7 @@ export const CacheMixin = dedupingMixin( base => {
       });
     }
 
-    getCache( url, resolveIfExpired ) {
+    getCache( url, ignoreExpiration ) {
       var _cache;
 
       return this._getCache().then( cache => {
@@ -68,7 +68,7 @@ export const CacheMixin = dedupingMixin( base => {
         if ( response ) {
           const date = new Date( response.headers.get( "date" ));
 
-          if ( resolveIfExpired || Date.now() < date.getTime() + this.cacheConfig.duration ) {
+          if ( ignoreExpiration || Date.now() < date.getTime() + this.cacheConfig.duration ) {
             return Promise.resolve( response );
 
           } else {

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -117,7 +117,7 @@ export const FetchMixin = dedupingMixin( base => {
     }
 
     _handleFetchError( err ) {
-      if ( !this._shouldRetryWithErrorHandling()) {
+      if ( this._requestRetryCount === 0 || this._requestRetryCount % this.fetchConfig.count !== 0 ) {
         this._requestRetryCount += 1;
 
         this._refresh( this.fetchConfig.retry );
@@ -136,9 +136,6 @@ export const FetchMixin = dedupingMixin( base => {
       }
     }
 
-    _shouldRetryWithErrorHandling() {
-      return this._requestRetryCount !== 0 && this._requestRetryCount % this.fetchConfig.count === 0;
-    }
   }
 
   return Fetch;

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -73,6 +73,7 @@ export const FetchMixin = dedupingMixin( base => {
     _requestData( cachedResp ) {
       return fetch( this._url, this._headers ).then( resp => {
         if ( resp.ok ) {
+          this._requestRetryCount = 0;
           this._logData( false );
           this._processData( resp.clone());
 
@@ -82,7 +83,9 @@ export const FetchMixin = dedupingMixin( base => {
         }
       }).catch( err => {
         return this._isOffline().then( isOffline => {
-          cachedResp && this._processData( Object.assign( cachedResp, { isOffline }));
+          if ( this._requestRetryCount === 0 ) {
+            cachedResp && this._processData( Object.assign( cachedResp, { isOffline }));
+          }
 
           this._handleFetchError( Object.assign( err, { isOffline }));
         });

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -117,7 +117,7 @@ export const FetchMixin = dedupingMixin( base => {
     }
 
     _handleFetchError( err ) {
-      if ( this._requestRetryCount === 0 || this._requestRetryCount % this.fetchConfig.count !== 0 ) {
+      if ( !this._shouldRetryWithErrorHandling()) {
         this._requestRetryCount += 1;
 
         this._refresh( this.fetchConfig.retry );
@@ -136,6 +136,9 @@ export const FetchMixin = dedupingMixin( base => {
       }
     }
 
+    _shouldRetryWithErrorHandling() {
+      return this._requestRetryCount !== 0 && this._requestRetryCount % this.fetchConfig.count === 0;
+    }
   }
 
   return Fetch;

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -117,12 +117,12 @@ export const FetchMixin = dedupingMixin( base => {
     }
 
     _handleFetchError( err ) {
-      if ( this._requestRetryCount === 0 || this._requestRetryCount % this.fetchConfig.count !== 0 ) {
+      if ( this._requestRetryCount < this.fetchConfig.count ) {
         this._requestRetryCount += 1;
 
         this._refresh( this.fetchConfig.retry );
       } else {
-        this._requestRetryCount += 1;
+        this._requestRetryCount = 0;
 
         if ( err && err.isOffline ) {
           super.log( "error", "client offline", { error: err ? err.message : null });

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -117,12 +117,12 @@ export const FetchMixin = dedupingMixin( base => {
     }
 
     _handleFetchError( err ) {
-      if ( this._requestRetryCount < this.fetchConfig.count ) {
+      if ( this._requestRetryCount === 0 || this._requestRetryCount % this.fetchConfig.count !== 0 ) {
         this._requestRetryCount += 1;
 
         this._refresh( this.fetchConfig.retry );
       } else {
-        this._requestRetryCount = 0;
+        this._requestRetryCount += 1;
 
         if ( err && err.isOffline ) {
           super.log( "error", "client offline", { error: err ? err.message : null });

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -117,7 +117,7 @@ export const FetchMixin = dedupingMixin( base => {
     }
 
     _handleFetchError( err ) {
-      if ( this._requestRetryCount < this.fetchConfig.count ) {
+      if ( !this._isMaxRetryAttempt()) {
         this._requestRetryCount += 1;
 
         this._refresh( this.fetchConfig.retry );
@@ -134,6 +134,10 @@ export const FetchMixin = dedupingMixin( base => {
 
         this._refresh( this.fetchConfig.cooldown );
       }
+    }
+
+    _isMaxRetryAttempt() {
+      return this._requestRetryCount >= this.fetchConfig.count;
     }
 
   }

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -30,10 +30,6 @@ export const FetchMixin = dedupingMixin( base => {
 
       this.processData = processData;
       this.processError = processError;
-
-      super.initCache && super.initCache({
-        refresh: this.fetchConfig.refresh
-      });
     }
 
     fetch( url, headers ) {

--- a/test/unit/cache-mixin.html
+++ b/test/unit/cache-mixin.html
@@ -24,7 +24,7 @@
     }
   };
 
-  const keys = ['key1','key2'];
+  const keys = ['key1', 'key2', 'key3'];
   var cachesOpen = null;
 
   function createCacheStub() {
@@ -36,7 +36,9 @@
             get: function() {
               if (key === 'key1') {
                 return new Date(); //valid cache
-              } else {
+              } else if (key === 'key2') {
+                return new Date(Date.now() - 1000 * 60 * 60 * 3); //expired duration
+              } else if (key === 'key3') {
                 return new Date('1980-01-01'); //expired cache
               }
             }
@@ -93,7 +95,9 @@
         cache.initCache();
 
         setTimeout(() => {
-          assert.isTrue( cachesOpen.delete.calledWith('key2'));
+          assert.isFalse( cachesOpen.delete.calledWith('key1'));
+          assert.isFalse( cachesOpen.delete.calledWith('key2'));
+          assert.isTrue( cachesOpen.delete.calledWith('key3'));
 
           done();
         }, 10);
@@ -142,6 +146,26 @@
         });
       });
       
+      test( "should not delete expired cached data if expiry is valid", done => {
+        const expiration = new Date(Date.now() - 1000 * 60 * 60 * 3);
+        const validXmlData = "<report><observation temperature=\"12\"/><location/></report>",
+          cachedData = new Response(validXmlData,{headers:{date: expiration}});
+        cachesOpen = {
+          match: sinon.stub().resolves(cachedData),
+          delete: sinon.spy()
+        };
+        caches.open.resolves(cachesOpen);
+
+        cache.getCache("url").then(() => {
+          done("error");
+        }).catch((response) => {
+          assert.isFalse( cachesOpen.delete.called );
+          assert.equal( response, cachedData );
+
+          done();
+        });
+      });
+
       test( "should delete expired cached data", done => {
         const validXmlData = "<report><observation temperature=\"12\"/><location/></report>",
           cachedData = new Response(validXmlData,{headers:{date: new Date('1980-01-01')}});

--- a/test/unit/cache-mixin.html
+++ b/test/unit/cache-mixin.html
@@ -99,8 +99,8 @@
         }, 10);
       });
 
-      test( "should not clear old cache entries on init if explicitly required", done => {
-        cache.initCache({ preserveExpired: true });
+      test( "should not clear old cache entries on init if expiry === -1", done => {
+        cache.initCache({ expiry: -1 });
 
         setTimeout(() => {
           assert.isFalse( cachesOpen.delete.called );
@@ -150,7 +150,7 @@
           delete: sinon.spy()
         };
         caches.open.resolves(cachesOpen);
-      
+
         cache.getCache("url").then(() => {
           done("error");
         }).catch(() => {

--- a/test/unit/cache-mixin.html
+++ b/test/unit/cache-mixin.html
@@ -25,25 +25,29 @@
   };
 
   const keys = ['key1','key2'];
-  var cachesOpen = { 
-    keys: sinon.stub().resolves(keys),
-    match: function(key) {
-      let resp = {
-        headers: {
-          get: function() {
-            if (key === 'key1') {
-              return new Date(); //valid cache
-            } else {
-              return new Date('1980-01-01'); //expired cache
+  var cachesOpen = null;
+
+  function createCacheStub() {
+    return {
+      keys: sinon.stub().resolves(keys),
+      match: function(key) {
+        let resp = {
+          headers: {
+            get: function() {
+              if (key === 'key1') {
+                return new Date(); //valid cache
+              } else {
+                return new Date('1980-01-01'); //expired cache
+              }
             }
           }
-        }
-      };
-      return Promise.resolve(resp);
-    },
-    delete: sinon.spy(),
-    put: sinon.spy()
-  };
+        };
+        return Promise.resolve(resp);
+      },
+      delete: sinon.spy(),
+      put: sinon.spy()
+    };
+  }
 </script>
 
 <script type="module">
@@ -59,6 +63,7 @@
       logger = cache.__proto__.__proto__;
       sinon.stub(logger, "log");
 
+      cachesOpen = createCacheStub();
       sinon.stub(caches, "open").resolves(cachesOpen);
     });
 
@@ -83,12 +88,22 @@
     });
 
     suite("deleteExpiredCache", () => {
-      
+
       test( "should clear old cache entries on init", done => {
         cache.initCache();
 
         setTimeout(() => {
           assert.isTrue( cachesOpen.delete.calledWith('key2'));
+
+          done();
+        }, 10);
+      });
+
+      test( "should not clear old cache entries on init if explicitly required", done => {
+        cache.initCache({ preserveExpired: true });
+
+        setTimeout(() => {
+          assert.isFalse( cachesOpen.delete.called );
 
           done();
         }, 10);

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -136,6 +136,8 @@
       });
 
       test( "should only provide data to client on the first try", done => {
+        let testCallCount = 7;
+
         cacheMixin.getCache = sinon.stub().rejects();
         cacheMixin.putCache = sinon.stub().resolves();
         window.fetch.rejects();
@@ -143,14 +145,12 @@
         sinon.stub(fetchMixin, "_processData");
         sinon.stub(fetchMixin, "_refresh");
 
-        fetchMixin._requestData(response);
-        fetchMixin._requestData(response);
-        fetchMixin._requestData(response);
-        fetchMixin._requestData(response);
-        fetchMixin._requestData(response);
+        for (var i = 0; i < testCallCount; i++) {
+          fetchMixin._requestData(response);
+        }
 
         setTimeout(() => {
-          assert.equal( fetchMixin._refresh.callCount, 5 );
+          assert.equal( fetchMixin._refresh.callCount, testCallCount );
           assert.isTrue( fetchMixin._processData.calledOnce );
 
           done();
@@ -167,6 +167,22 @@
         setTimeout(() => {
           assert.isTrue( handleResponse.called );
           assert.isTrue( handleResponse.calledWith( response ) );          
+
+          done();
+        }, 10);
+      });
+
+      test( "should process data on successful requests and reset _requestRetryCount", done => {
+        cacheMixin.getCache = sinon.stub().rejects();
+        cacheMixin.putCache = sinon.stub().resolves();
+        window.fetch.resolves(response);
+        fetchMixin._requestRetryCount = 7;
+
+        fetchMixin._requestData();
+
+        setTimeout(() => {
+          assert.isTrue( handleResponse.called );
+          assert.isTrue( fetchMixin._requestRetryCount === 0 );
 
           done();
         }, 10);
@@ -261,7 +277,7 @@
           fetchMixin._requestRetryCount = 5;
           fetchMixin._handleFetchError();
 
-          assert.isTrue( fetchMixin._requestRetryCount === 0 );
+          assert.equal( fetchMixin._requestRetryCount, 6 );
           assert.isTrue( fetchMixin._refresh.called );
           assert.isTrue( fetchMixin._refresh.calledWith(1000 * 60 * 10) );
 

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -136,8 +136,6 @@
       });
 
       test( "should only provide data to client on the first try", done => {
-        let testCallCount = 7;
-
         cacheMixin.getCache = sinon.stub().rejects();
         cacheMixin.putCache = sinon.stub().resolves();
         window.fetch.rejects();
@@ -145,12 +143,14 @@
         sinon.stub(fetchMixin, "_processData");
         sinon.stub(fetchMixin, "_refresh");
 
-        for (var i = 0; i < testCallCount; i++) {
-          fetchMixin._requestData(response);
-        }
+        fetchMixin._requestData(response);
+        fetchMixin._requestData(response);
+        fetchMixin._requestData(response);
+        fetchMixin._requestData(response);
+        fetchMixin._requestData(response);
 
         setTimeout(() => {
-          assert.equal( fetchMixin._refresh.callCount, testCallCount );
+          assert.equal( fetchMixin._refresh.callCount, 5 );
           assert.isTrue( fetchMixin._processData.calledOnce );
 
           done();
@@ -167,22 +167,6 @@
         setTimeout(() => {
           assert.isTrue( handleResponse.called );
           assert.isTrue( handleResponse.calledWith( response ) );          
-
-          done();
-        }, 10);
-      });
-
-      test( "should process data on successful requests and reset _requestRetryCount", done => {
-        cacheMixin.getCache = sinon.stub().rejects();
-        cacheMixin.putCache = sinon.stub().resolves();
-        window.fetch.resolves(response);
-        fetchMixin._requestRetryCount = 7;
-
-        fetchMixin._requestData();
-
-        setTimeout(() => {
-          assert.isTrue( handleResponse.called );
-          assert.isTrue( fetchMixin._requestRetryCount === 0 );
 
           done();
         }, 10);
@@ -277,7 +261,7 @@
           fetchMixin._requestRetryCount = 5;
           fetchMixin._handleFetchError();
 
-          assert.equal( fetchMixin._requestRetryCount, 6 );
+          assert.isTrue( fetchMixin._requestRetryCount === 0 );
           assert.isTrue( fetchMixin._refresh.called );
           assert.isTrue( fetchMixin._refresh.calledWith(1000 * 60 * 10) );
 

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -136,6 +136,8 @@
       });
 
       test( "should only provide data to client on the first try", done => {
+        let testCallCount = 7;
+
         cacheMixin.getCache = sinon.stub().rejects();
         cacheMixin.putCache = sinon.stub().resolves();
         window.fetch.rejects();
@@ -143,15 +145,13 @@
         sinon.stub(fetchMixin, "_processData");
         sinon.stub(fetchMixin, "_refresh");
 
-        fetchMixin._requestData(response);
-        fetchMixin._requestData(response);
-        fetchMixin._requestData(response);
-        fetchMixin._requestData(response);
-        fetchMixin._requestData(response);
+        for (var i = 0; i < testCallCount; i++) {
+          fetchMixin._requestData(response);
+        }
 
         setTimeout(() => {
-          assert.equal( fetchMixin._refresh.callCount, 5 );
-          assert.isTrue( fetchMixin._processData.calledOnce );
+          assert.equal( fetchMixin._refresh.callCount, testCallCount );
+          assert.isTrue( fetchMixin._processData.calledTwice );
 
           done();
         }, 10);
@@ -167,6 +167,22 @@
         setTimeout(() => {
           assert.isTrue( handleResponse.called );
           assert.isTrue( handleResponse.calledWith( response ) );          
+
+          done();
+        }, 10);
+      });
+
+      test( "should process data on successful requests and reset _requestRetryCount", done => {
+        cacheMixin.getCache = sinon.stub().rejects();
+        cacheMixin.putCache = sinon.stub().resolves();
+        window.fetch.resolves(response);
+        fetchMixin._requestRetryCount = 7;
+
+        fetchMixin._requestData();
+
+        setTimeout(() => {
+          assert.isTrue( handleResponse.called );
+          assert.isTrue( fetchMixin._requestRetryCount === 0 );
 
           done();
         }, 10);
@@ -261,7 +277,7 @@
           fetchMixin._requestRetryCount = 5;
           fetchMixin._handleFetchError();
 
-          assert.isTrue( fetchMixin._requestRetryCount === 0 );
+          assert.equal( fetchMixin._requestRetryCount, 0 );
           assert.isTrue( fetchMixin._refresh.called );
           assert.isTrue( fetchMixin._refresh.calledWith(1000 * 60 * 10) );
 

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -162,6 +162,58 @@
         });
       });
 
+      test( "should handle request http response failures and return cached data if offline", done => {
+        fetchMixin.initFetch({
+          useCacheIfOffline: true
+        }, handleResponse, handleError );
+
+        cacheMixin.putCache = sinon.stub().resolves();
+        cacheMixin.getCache = sinon.stub().callsFake(function (url, ignoreExpiration) {
+          if (ignoreExpiration) {
+            return Promise.resolve(response);
+          } else {
+            return Promise.reject();
+          }
+        });
+
+        // Check for widgets.risevision.com will fail since fetch always rejects
+        window.fetch.rejects();
+
+        fetchMixin._requestData().then(() => {
+          assert.isTrue( handleResponse.called );
+          assert.isTrue( handleResponse.calledWith( response ) );
+
+          done();
+        });
+      });
+
+      test( "should handle request http response failures and fail if online", done => {
+        fetchMixin.initFetch({
+          useCacheIfOffline: true
+        }, handleResponse, handleError );
+
+        cacheMixin.putCache = sinon.stub().resolves();
+        cacheMixin.getCache = sinon.stub().callsFake(function (url, ignoreExpiration) {
+          if (ignoreExpiration) {
+            return Promise.resolve(response);
+          } else {
+            return Promise.reject();
+          }
+        });
+
+        window.fetch.onFirstCall().rejects();
+        // Check for widgets.risevision.com will succeed
+        window.fetch.onSecondCall().resolves(response);
+
+        sinon.stub(fetchMixin, "_handleFetchError");
+
+        fetchMixin._requestData().then(() => {
+          assert.isTrue( fetchMixin._handleFetchError.called );
+
+          done();
+        });
+      });
+
       suite( "data refresh mechanism", () => {
         let clock;
         

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -241,7 +241,7 @@
           assert.isTrue( handleError.called );
         });
 
-        test( "should call handleError on request failures while offline", done => {
+        test( "should call handleError on request failures while offline", () => {
           sinon.stub(fetchMixin, "_refresh");
 
           fetchMixin._requestRetryCount = 5;

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -50,17 +50,18 @@
 
     suite( "_getData", () => {
       test( "should get the result from cache", done => {
-        cacheMixin.getCache = sinon.stub().resolves("text");
+        cacheMixin.getCache = sinon.stub().resolves( new Response("text") );
         sinon.stub(fetchMixin, "_requestData");
 
         fetchMixin._getData().then(() => {
           assert.isTrue( cacheMixin.getCache.called );
           assert.isTrue( handleResponse.called );
-          assert.isTrue( handleResponse.calledWith("text") );          
-
           assert.isFalse( fetchMixin._requestData.called );
 
-          done();
+          handleResponse.getCall(0).args[0].text().then( text => {
+            assert.equal( text, "text" );
+            done();
+          });
         });
       });
 
@@ -162,53 +163,14 @@
         });
       });
 
-      test( "should handle request http response failures and return cached data if offline", done => {
-        fetchMixin.initFetch({
-          useCacheIfOffline: true
-        }, handleResponse, handleError );
-
-        cacheMixin.putCache = sinon.stub().resolves();
-        cacheMixin.getCache = sinon.stub().callsFake(function (url, ignoreExpiration) {
-          if (ignoreExpiration) {
-            return Promise.resolve(response);
-          } else {
-            return Promise.reject();
-          }
-        });
-
+      test( "should handle request http response failures and return cached data indicating if it's offline", done => {
         // Check for widgets.risevision.com will fail since fetch always rejects
         window.fetch.rejects();
 
-        fetchMixin._requestData().then(() => {
+        fetchMixin._requestData( response ).then(() => {
           assert.isTrue( handleResponse.called );
           assert.isTrue( handleResponse.calledWith( response ) );
-
-          done();
-        });
-      });
-
-      test( "should handle request http response failures and fail if online", done => {
-        fetchMixin.initFetch({
-          useCacheIfOffline: true
-        }, handleResponse, handleError );
-
-        cacheMixin.putCache = sinon.stub().resolves();
-        cacheMixin.getCache = sinon.stub().callsFake(function (url, ignoreExpiration) {
-          if (ignoreExpiration) {
-            return Promise.resolve(response);
-          } else {
-            return Promise.reject();
-          }
-        });
-
-        window.fetch.onFirstCall().rejects();
-        // Check for widgets.risevision.com will succeed
-        window.fetch.onSecondCall().resolves(response);
-
-        sinon.stub(fetchMixin, "_handleFetchError");
-
-        fetchMixin._requestData().then(() => {
-          assert.isTrue( fetchMixin._handleFetchError.called );
+          assert.isTrue( handleResponse.getCall(0).args[0].isOffline );
 
           done();
         });
@@ -275,6 +237,18 @@
           fetchMixin._handleFetchError( new Error("error") );
 
           assert.deepEqual(loggerMixin.log.getCall(0).args, ["error", "request error", {error: "error"}]);
+
+          assert.isTrue( handleError.called );
+        });
+
+        test( "should call handleError on request failures while offline", done => {
+          sinon.stub(fetchMixin, "_refresh");
+
+          fetchMixin._requestRetryCount = 5;
+
+          fetchMixin._handleFetchError( { message: "error", isOffline: true } );
+
+          assert.deepEqual(loggerMixin.log.getCall(0).args, ["error", "client offline", {error: "error"}]);
 
           assert.isTrue( handleError.called );
         });

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -117,6 +117,46 @@
         });
       });
 
+      test( "should use expired cached data if provided by caller", done => {
+        cacheMixin.getCache = sinon.stub().rejects();
+        cacheMixin.putCache = sinon.stub().resolves();
+        window.fetch.rejects();
+
+        sinon.stub(fetchMixin, "_handleFetchError");
+        sinon.stub(fetchMixin, "_processData");
+
+        fetchMixin._requestData(response);
+
+        setTimeout(() => {
+          assert.isTrue( fetchMixin._handleFetchError.called );
+          assert.isTrue( fetchMixin._processData.called );
+
+          done();
+        }, 10);
+      });
+
+      test( "should only provide data to client on the first try", done => {
+        cacheMixin.getCache = sinon.stub().rejects();
+        cacheMixin.putCache = sinon.stub().resolves();
+        window.fetch.rejects();
+
+        sinon.stub(fetchMixin, "_processData");
+        sinon.stub(fetchMixin, "_refresh");
+
+        fetchMixin._requestData(response);
+        fetchMixin._requestData(response);
+        fetchMixin._requestData(response);
+        fetchMixin._requestData(response);
+        fetchMixin._requestData(response);
+
+        setTimeout(() => {
+          assert.equal( fetchMixin._refresh.callCount, 5 );
+          assert.isTrue( fetchMixin._processData.calledOnce );
+
+          done();
+        }, 10);
+      });
+
       test( "should process data on successful requests", done => {
         cacheMixin.getCache = sinon.stub().rejects();
         cacheMixin.putCache = sinon.stub().resolves();


### PR DESCRIPTION
## Description
This adds support for offline play, using cached data. In case a fetch request fails and we detect the client is offline, we will try to deliver the latest cached response (ignoring expiration date).

To detect if the machine is offline we rely on https://widgets.risevision.com, which should be available in the users machine and has appropriate CORS settings.

## Motivation and Context
Rise Image and Rise Video handle cached content using Player provided features. These are not available, as far as I understand, for content not hosted on GCS. Rise RSS needs to support offline play.

## How Has This Been Tested?
Testing has been performed using Chrome Dev Tools to simulate offline scenarios, while using the Demo page for `rise-data-rss`. More specifically, a breakpoint was set before performing the first `fetch` call and only then the Offline mode was set (otherwise Chrome does not load the Demo page, which is served through a local web server).

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No. This changeset will only impact components which specifically use the new tag.

----

I thought about creating a completely separate mixin, but there were many features I needed from the existing `CacheMixin` and `FetchMixin` mixins; adding two new configuration flags made more sense.

@santiagonoguez @stulees please review

@alex-deaconu you are the main contributor to these two mixins. Can I bother you to take a look? Thanks!