### PR TITLE
Handle disk space errors separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "prebuild": "eslint . && ./scripts/create_config.sh prod rise-element",

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -122,7 +122,8 @@ export const WatchFilesMixin = dedupingMixin( base => {
     _handleSingleFileError( message ) {
       const { filePath, fileUrl } = message,
         details = { filePath, errorMessage: message.errorMessage, errorDetail: message.errorDetail },
-        fileInError = this._getManagedFileInError( filePath );
+        fileInError = this._getManagedFileInError( filePath ),
+        errorName = message.errorMessage === "Insufficient disk space" ? "file-insufficient-disk-space-error" : "file-rls-error";
 
       // prevent repetitive logging when component instance is receiving messages from other potential component instances watching same file
       // Note: to avoid using Lodash or Underscore library for just a .isEqual() function, taking a simple approach to object comparison with JSON.stringify()
@@ -142,7 +143,7 @@ export const WatchFilesMixin = dedupingMixin( base => {
         "Invalid response with status code [CODE]"
        */
 
-      this.log( WatchFiles.LOG_TYPE_ERROR, "file-rls-error", {
+      this.log( WatchFiles.LOG_TYPE_ERROR, errorName, {
         errorMessage: message.errorMessage,
         errorDetail: message.errorDetail
       }, {

--- a/test/unit/watch-files-mixin.html
+++ b/test/unit/watch-files-mixin.html
@@ -79,6 +79,8 @@
       } );
 
       test( "should handle file errors", () => {
+        sinon.spy( watchFiles, "log" );
+
         watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] );
 
         watchFiles._handleSingleFileUpdate( {
@@ -90,8 +92,56 @@
         } );
 
         assert.equal( watchFiles.watchedFileErrorCallback.callCount, 1 );
+        assert.deepEqual( watchFiles.log.lastCall.args, [
+          "error",
+          "file-rls-error",
+          {
+            errorMessage: "Network error",
+            errorDetail: "Detailed network error"
+          },
+          {
+            storage: {
+              configuration: "storage file",
+              file_form: "jpg",
+              file_path: "foo.jpg",
+              local_url: sampleUrl( "foo.jpg" )
+            }
+          }
+        ]);
         assert.equal (watchFiles.managedFiles.length, 1 );
         assert.equal (watchFiles._managedFilesInError.length, 1 );
+
+        watchFiles.log.restore();
+      } );
+
+      test( "should handle insufficient disk space errors", () => {
+        sinon.spy( watchFiles, "log" );
+
+        watchFiles._handleSingleFileError( {
+          filePath: "baz.mp4",
+          fileUrl: sampleUrl( "baz.mp4" ),
+          errorMessage: "Insufficient disk space",
+          errorDetail: ""
+        } );
+
+        assert.deepEqual( watchFiles.log.lastCall.args, [
+          "error",
+          "file-insufficient-disk-space-error",
+          {
+            errorMessage: "Insufficient disk space",
+            errorDetail: ""
+          },
+          {
+            storage: {
+              configuration: "storage file",
+              file_form: "mp4",
+              file_path: "baz.mp4",
+              local_url: sampleUrl( "baz.mp4" )
+            }
+          }
+        ]);
+
+        watchFiles.log.restore();
       } );
 
       test( "should handle deleting files", () => {


### PR DESCRIPTION
## Description

Log `Insufficient disk space` errors separately from general `rls-file-error` errors.

## Motivation and Context

Work related to [this Trello card](https://trello.com/c/RbKtu63S)

## How Has This Been Tested?

Automated tests have been added and manual testing performed as noted below.

Code has been pushed to [GCS here](https://widgets.risevision.com/staging/components/rise-video/2019.08.15.19.30/rise-video.js) and an example template using a version of `rise-video` modified to use this code has been deployed [here](https://widgets.risevision.com/stable/templates/a4ef37a0486832bcc7d087a9b6dead1ea41a4f18/src/template.html) and added to a schedule [here](https://apps.risevision.com/schedules/details/affc198c-62ad-48df-8e72-bc9e13c3395e?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f)

- Add your player to the example schedule
- Open development tools in your player
- Run the following javascript:

```
let riseVideo = document.querySelector('rise-video');
riseVideo._handleSingleFileError({filePath: riseVideo.managedFiles[0].filePath, fileUrl: riseVideo.managedFiles[0].fileUrl, errorMessage: "Insufficient disk space", errorDetail: ""});
riseVideo._handleSingleFileError({filePath: riseVideo.managedFiles[0].filePath, fileUrl: riseVideo.managedFiles[0].fileUrl, errorMessage: "Network error", errorDetail: ""});
```

- Validate that two GBQ events are logged, one with an error name of "file-rls-error" and one with an error name of "file-insufficient-disk-space-error"

**Note:**_The video will stop playing but this is expected behavior because the two managed files are removed from the playlist due to the simulated errors_

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manual Test: Completed as noted above
  - Automated Test: Added as noted above.
  - Monitoring: Changes will be manually tested after pushing to Production. Since this is a library there's minimal risk to merging on a Friday.
  - Rollback: Revert to the previous release
  - Documentation: No documentation updates required
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

It should be OK to release on a Friday due to this being a library.