### PR TITLE
Add all-formats-invalid error

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ In case you need to specify an error state, you can set `RiseElement._setUptimeE
 
 ### Valid Files Mixin
 
-Used to validate that a list of files has the expected extensions and to log related errors to GBQ.
+Used to validate that a list of files has the expected extensions and to log related errors to BQ.
 
 Provides a `validateFiles( files, extensions )` function, which accepts:
 
@@ -251,7 +251,7 @@ Returns an object containing arrays of all valid / invalid files, ie:
 }
 `
 
-Logs the following errors to GBQ:
+Logs the following errors to BQ:
 
 - `format-invalid` - A file with an invalid extension is encountered
 - `all-formats-invalid` - All files have invalid formats
@@ -298,7 +298,7 @@ class RiseExample extends ValidFilesMixin( RiseElement ) {
 
   - `managedFiles` - A list of watched files which are currently available
 
-  Logs the following errors to GBQ:
+  Logs the following errors to BQ:
 
   - `file-not-found` - Logged when a watched file is not found
   - `file-insufficient-disk-space-error` - Logged when a watched file can not be downloaded due to a lack of disk space

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ class RiseDataWeather extends RiseElement {}
 `super._setVersion( version )` should always be called as part of the constructor. This will pass your component version to `RiseElement` for logging purposes.
 
 `RiseElement` provides a few utility functions:
-- `ready()` is called by the Component once initialized. 
+- `ready()` is called by the Component once initialized.
 - `_init()` is called once RisePlayerConfiguration has been initialized.
 - `_handleStart()` is called once the Component is required to start playing.
 
@@ -88,7 +88,7 @@ super.log( "error", "data error", { error: e.message });
 
 ### Caching Mechanism
 
-For caching arbitrary data responses, the mixin uses browsers Cache API. 
+For caching arbitrary data responses, the mixin uses browsers Cache API.
 
 Whenever the cached data is retrieved, the mixin checks the date header and delete it from cache in case it is expired. Also, to prevent cache from growing indefinitely, during mixin initialization all expired cache entries are deleted.
 
@@ -162,7 +162,7 @@ _getData() {
 
 ### Fetch Mechanism
 
-Used to fetch data from an API, the mixin uses browsers Fetch API. 
+Used to fetch data from an API, the mixin uses browsers Fetch API.
 
 The mixin can optionally use the cacheMixin for Caching purposes.
 
@@ -232,6 +232,58 @@ In case you need to specify an error state, you can set `RiseElement._setUptimeE
 
 ### Play Until Done
 `RiseElement` provides the `_sendDoneEvent(done)` method for components to report when it is done.
+
+### Valid Files Mixin
+
+Used to validate that a list of files has the expected extensions and to log related errors to GBQ.
+
+Provides a `validateFiles( files, extensions )` function, which accepts:
+
+- an array of filenames, ie: `["video1.mp4", "video2.webm"]`
+- an array of allowed extensions, ie: `["mp4", "webm"]`
+
+Returns an object containing arrays of all valid / invalid files, ie:
+
+`
+{
+  validFiles: ["video1.mp4", "video2.webm"],
+  invalidFiles: []
+}
+`
+
+If a file with an invalid extension is encountered, a `format-invalid` error is logged to GBQ.
+
+If all provided files have invalid extensions, an `all-formats-invalid` error is logged to GBQ.
+
+### Valid Files Mixin Example
+
+```
+import { RiseElement } from "rise-common-component/src/rise-element.js";
+import { ValidFilesMixin } from "rise-common-component/src/valid-files-mixin.js";
+
+const VALID_FILE_TYPES = ["mp4", "webm"];
+
+class RiseExample extends ValidFilesMixin( RiseElement ) {
+  static get properties() {
+    return {
+      files: {
+        type: Array,
+        value: []
+      }
+    }
+  }
+
+  ready() {
+    super.ready();
+  }
+
+  _handleStart() {
+    const validFiles = this.validateFiles( this.files, VALID_FILE_TYPES );
+  }
+
+  ...
+}
+```
 
 ## Built With
 - [Polymer 3](https://www.polymer-project.org/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "prebuild": "eslint . && ./scripts/create_config.sh prod rise-element",

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -76,7 +76,7 @@ export const ValidFilesMixin = dedupingMixin( base => {
 
       if ( files.length && !validFiles.length ) {
         this.log( ValidFiles.LOG_TYPE_ERROR, "all-formats-invalid", null, {
-          files,
+          files: files,
           errorMessage: "All file formats are invalid"
         });
       }

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -74,6 +74,13 @@ export const ValidFilesMixin = dedupingMixin( base => {
         });
       });
 
+      if ( files.length && !validFiles.length ) {
+        this.log( ValidFiles.LOG_TYPE_ERROR, "all-formats-invalid", null, {
+          files,
+          errorMessage: "All file formats are invalid"
+        });
+      }
+
       return { validFiles, invalidFiles };
     }
 

--- a/src/valid-files-mixin.js
+++ b/src/valid-files-mixin.js
@@ -64,7 +64,7 @@ export const ValidFilesMixin = dedupingMixin( base => {
       });
 
       invalidFiles.forEach( invalidFile => {
-        this.log( ValidFiles.LOG_TYPE_ERROR, "format-invalid", null, {
+        super.log( ValidFiles.LOG_TYPE_ERROR, "format-invalid", null, {
           storage: {
             configuration: "storage file",
             file_form: this._getStorageFileFormat( invalidFile ),
@@ -75,8 +75,8 @@ export const ValidFilesMixin = dedupingMixin( base => {
       });
 
       if ( files.length && !validFiles.length ) {
-        this.log( ValidFiles.LOG_TYPE_ERROR, "all-formats-invalid", null, {
-          files: files,
+        super.log( ValidFiles.LOG_TYPE_ERROR, "all-formats-invalid", {
+          files,
           errorMessage: "All file formats are invalid"
         });
       }

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -115,7 +115,6 @@ export const WatchFilesMixin = dedupingMixin( base => {
       this._watchInitiated = false;
       this.managedFiles = [];
       this._managedFilesInError = [];
-      this._filesToRenderList = [];
       this._filesList = [];
     }
 

--- a/test/unit/valid-files-mixin.html
+++ b/test/unit/valid-files-mixin.html
@@ -126,7 +126,7 @@
         validFiles._filterInvalidFileTypes( [ "test1.txt", "test2.zip", "test3.pdf"], [ "jpg,", "png"] );
 
         assert.equal( RisePlayerConfiguration.Logger.error.lastCall.args[1], "all-formats-invalid" );
-        assert.deepEqual( RisePlayerConfiguration.Logger.error.lastCall.args[3], {
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.lastCall.args[2], {
           files: [ "test1.txt", "test2.zip", "test3.pdf" ],
           errorMessage: "All file formats are invalid"
         });

--- a/test/unit/valid-files-mixin.html
+++ b/test/unit/valid-files-mixin.html
@@ -121,6 +121,16 @@
           }
         });
       } )
+
+      test( "should log a 'all-formats-invalid' error if all files are invalid", () => {
+        validFiles._filterInvalidFileTypes( [ "test1.txt", "test2.zip", "test3.pdf"], [ "jpg,", "png"] );
+
+        assert.equal( RisePlayerConfiguration.Logger.error.lastCall.args[1], "all-formats-invalid" );
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.lastCall.args[3], {
+          files: [ "test1.txt", "test2.zip", "test3.pdf" ],
+          errorMessage: "All file formats are invalid"
+        });
+      })
     } );
   });
 </script>


### PR DESCRIPTION
## Description

Move `all-formats-invalid` error from `rise-image` to the shared `ValidFilesMixin`. Also adds documentation for new mixins.

## Motivation and Context

While working on [this rise-image PR](https://github.com/Rise-Vision/rise-image/pull/41), it made sense to move the `all-formats-invalid` code to the shared `ValidFilesMixin` so it can be used by other components as well.

## How Has This Been Tested?

A test template which uses this new code has been deployed [here](https://widgets.risevision.com/staging/pages/2019.09.03.08.39/src/rise-image.html) and added to a [schedule here](https://github.com/Rise-Vision/rise-image/pull/41).

After adding a display to the schedule, open the Chrome inspector and run the following code:

`document.getElementById('rise-image-01').files = "foo.txt|bar.pdf";`

Afterwards, validate that an `all-formats-invalid` error is logged to GBQ.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No release checklist items were skipped.
