### PR TITLE
Rename duration to refresh for cache and init default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,17 @@ For caching arbitrary data responses, the mixin uses browsers Cache API.
 
 Whenever the cached data is retrieved, the mixin checks the date header and delete it from cache in case it is expired. Also, to prevent cache from growing indefinitely, during mixin initialization all expired cache entries are deleted.
 
-To enable the mixin in your component you have to declare the mixin and call the `initCache` function with your desired cache name and optionally duration. Cache duration defaults to 2h. Cache expiry defaults to 4h. For greater certainty:
+To enable the mixin in your component you have to declare the mixin and call the `initCache` function with your desired cache name and optionally refresh. Cache refresh defaults to 2h. Cache expiry defaults to 4h. For greater certainty:
 
-- `duration` is how long a cache entry is valid, after which data will be requested again
-- `expiration` is how long a cache entry is kept for offline, before it gets removed from the cache
+- `refresh` is how long a cache entry is valid, after which data will be requested again
+- `expiry` is how long a cache entry is kept for offline, before it gets removed from the cache
+
+Note: if using `fetchMixin`, it will automatically call, however can overwrite that by calling `initCache` after `initFetch`:
+```
+initCache({
+  refresh: this.fetchConfig.refresh - 5 * 1000
+});
+```
 
 Setting any of the timers to -1 ignores that functionality and either hits the API every time (except for offline) or uses the offline version all the time (until it expires).
 
@@ -104,8 +111,8 @@ Default values are:
 ```
 {
   name: "cache-mixin",
-  duration: 1000 * 60 * 60 * 2,
-  expiry: 1000 * 60 * 60 * 2
+  refresh: 1000 * 60 * 60 * 2,
+  expiry: 1000 * 60 * 60 * 4
 }
 ```
 
@@ -114,7 +121,7 @@ To use the `cacheMixin`, there are two functions:
 
 `super.putCache( response )` adds your response to the cache.
 
-`super.getCache( url )` retrieves your response by resource `url` via a `Promise`. If the resource is not available or it has expired from Cache (see the `duration` variable), the promise will reject.
+`super.getCache( url )` retrieves your response by resource `url` via a `Promise`. If the resource is not available or it has expired from Cache (see the `refresh` variable), the promise will reject.
 
 
 #### Caching Example
@@ -133,7 +140,7 @@ ready() {
 
   super.initCache({
     name: this.tagName.toLowerCase(),
-    duration: 1000 * 60 * 60
+    refresh: 1000 * 60 * 60
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "prebuild": "eslint . && ./scripts/create_config.sh prod rise-element",

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -4,7 +4,7 @@ import { LoggerMixin } from "./logger-mixin.js";
 export const CacheMixin = dedupingMixin( base => {
   const CACHE_CONFIG = {
       name: "cache-mixin",
-      duration: 1000 * 60 * 60 * 2,
+      refresh: 1000 * 60 * 60 * 2,
       expiry: 1000 * 60 * 60 * 4
     },
     cacheBase = LoggerMixin( base );
@@ -71,7 +71,7 @@ export const CacheMixin = dedupingMixin( base => {
         _cache = cache;
         return cache.match( url );
       }).then( response => {
-        if ( !this._isResponseExpired( response, this.cacheConfig.duration )) {
+        if ( !this._isResponseExpired( response, this.cacheConfig.refresh )) {
           return Promise.resolve( response );
         } else if ( !this._isResponseExpired( response, this.cacheConfig.expiry )) {
           return Promise.reject( response );

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -30,6 +30,10 @@ export const FetchMixin = dedupingMixin( base => {
 
       this.processData = processData;
       this.processError = processError;
+
+      super.initCache && super.initCache({
+        refresh: this.fetchConfig.refresh - (( this.fetchConfig.refresh > 10 * 1000 ) ? 5 * 1000 : 0 )
+      });
     }
 
     fetch( url, headers ) {

--- a/test/unit/cache-mixin.html
+++ b/test/unit/cache-mixin.html
@@ -37,7 +37,7 @@
               if (key === 'key1') {
                 return new Date(); //valid cache
               } else if (key === 'key2') {
-                return new Date(Date.now() - 1000 * 60 * 60 * 3); //expired duration
+                return new Date(Date.now() - 1000 * 60 * 60 * 3); //expired "refresh" duration
               } else if (key === 'key3') {
                 return new Date('1980-01-01'); //expired cache
               }


### PR DESCRIPTION
## Description
Rename duration to refresh for cache

Init cache refresh from fetch
Set it to fetch refresh - 5s

Note: Bumping minor version as this is a breaking change.

## Motivation and Context
Renaming the `refresh` variable forces consistency between the two mixins where that variable should technically be common.
Passing the default refresh value reduces the amount of configuration needed as well as the logic around timeout inconsistencies via the 5s reduction.

## How Has This Been Tested?
Validated the change locally via the rise-data-weather component.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
