### PR TITLE
Feature/log file not exist as warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,9 +307,12 @@ class RiseExample extends ValidFilesMixin( RiseElement ) {
 
   Logs the following errors to BQ:
 
-  - `file-not-found` - Logged when a watched file is not found
   - `file-insufficient-disk-space-error` - Logged when a watched file can not be downloaded due to a lack of disk space
   - `file-rls-error` - Logged when a general RLS error is encountered for a watched file
+
+  Logs the following warnings to BQ:
+
+  - `file-not-found` - Logged when a watched file is referenced by the attribute data, but does not exist anymore on storage.
 
 ### Watch Files Mixin Example
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "prebuild": "eslint . && ./scripts/create_config.sh prod rise-element",

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -122,7 +122,9 @@ export const WatchFilesMixin = dedupingMixin( base => {
       const { filePath, fileUrl } = message,
         details = { filePath, errorMessage: message.errorMessage, errorDetail: message.errorDetail },
         fileInError = this._getManagedFileInError( filePath ),
-        errorName = ( "NOEXIST" === message.status.toUpperCase() && !message.errorMessage ) ? "file-not-found" :
+        isFileNotFound = "NOEXIST" === message.status.toUpperCase() && !message.errorMessage,
+        logLevel = isFileNotFound ? WatchFiles.LOG_TYPE_WARNING : WatchFiles.LOG_TYPE_ERROR,
+        errorName = isFileNotFound ? "file-not-found" :
           ( message.errorMessage === "Insufficient disk space" ? "file-insufficient-disk-space-error" : "file-rls-error" );
 
       // prevent repetitive logging when component instance is receiving messages from other potential component instances watching same file
@@ -143,7 +145,7 @@ export const WatchFilesMixin = dedupingMixin( base => {
         "Invalid response with status code [CODE]"
        */
 
-      this.log( WatchFiles.LOG_TYPE_ERROR, errorName, {
+      this.log( logLevel, errorName, {
         errorMessage: message.errorMessage,
         errorDetail: message.errorDetail
       }, {

--- a/test/unit/watch-files-mixin.html
+++ b/test/unit/watch-files-mixin.html
@@ -78,86 +78,115 @@
         assert.equal ( watchFiles.managedFiles.length, 2);
       } );
 
-      test( "should handle file errors", () => {
-        sinon.spy( watchFiles, "log" );
-
-        watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] );
-
-        watchFiles._handleSingleFileUpdate( {
-          filePath: "foo.jpg",
-          fileUrl: sampleUrl( "foo.jpg" ),
-          status: "file-error",
-          errorMessage: "Network error",
-          errorDetail: "Detailed network error"
+      suite( "handle errors", () => {
+        setup( () => {
+          sinon.spy( watchFiles, "log" );
         } );
 
-        assert.equal( watchFiles.watchedFileErrorCallback.callCount, 1 );
-        assert.deepEqual( watchFiles.log.lastCall.args, [
-          "error",
-          "file-rls-error",
-          {
+        teardown( () => {
+          watchFiles.log.restore();
+        } );
+
+        test( "should handle file errors", () => {
+          watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] );
+
+          watchFiles._handleSingleFileUpdate( {
+            filePath: "foo.jpg",
+            fileUrl: sampleUrl( "foo.jpg" ),
+            status: "file-error",
             errorMessage: "Network error",
             errorDetail: "Detailed network error"
-          },
-          {
-            storage: {
-              configuration: "storage file",
-              file_form: "jpg",
-              file_path: "foo.jpg",
-              local_url: sampleUrl( "foo.jpg" )
+          } );
+
+          assert.equal( watchFiles.watchedFileErrorCallback.callCount, 1 );
+          assert.deepEqual( watchFiles.log.lastCall.args, [
+            "error",
+            "file-rls-error",
+            {
+              errorMessage: "Network error",
+              errorDetail: "Detailed network error"
+            },
+            {
+              storage: {
+                configuration: "storage file",
+                file_form: "jpg",
+                file_path: "foo.jpg",
+                local_url: sampleUrl( "foo.jpg" )
+              }
             }
-          }
-        ]);
-        assert.equal (watchFiles.managedFiles.length, 1 );
-        assert.equal (watchFiles._managedFilesInError.length, 1 );
-
-        watchFiles.log.restore();
-      } );
-
-      test( "should handle insufficient disk space errors", () => {
-        sinon.spy( watchFiles, "log" );
-
-        watchFiles._handleSingleFileError( {
-          status: "FILE-ERROR",
-          filePath: "baz.mp4",
-          fileUrl: sampleUrl( "baz.mp4" ),
-          errorMessage: "Insufficient disk space",
-          errorDetail: ""
+          ]);
+          assert.equal (watchFiles.managedFiles.length, 1 );
+          assert.equal (watchFiles._managedFilesInError.length, 1 );
         } );
 
-        assert.deepEqual( watchFiles.log.lastCall.args, [
-          "error",
-          "file-insufficient-disk-space-error",
-          {
+        test( "should handle insufficient disk space errors", () => {
+          watchFiles._handleSingleFileError( {
+            status: "FILE-ERROR",
+            filePath: "baz.mp4",
+            fileUrl: sampleUrl( "baz.mp4" ),
             errorMessage: "Insufficient disk space",
             errorDetail: ""
-          },
-          {
-            storage: {
-              configuration: "storage file",
-              file_form: "mp4",
-              file_path: "baz.mp4",
-              local_url: sampleUrl( "baz.mp4" )
+          } );
+
+          assert.deepEqual( watchFiles.log.lastCall.args, [
+            "error",
+            "file-insufficient-disk-space-error",
+            {
+              errorMessage: "Insufficient disk space",
+              errorDetail: ""
+            },
+            {
+              storage: {
+                configuration: "storage file",
+                file_form: "mp4",
+                file_path: "baz.mp4",
+                local_url: sampleUrl( "baz.mp4" )
+              }
             }
-          }
-        ]);
-
-        watchFiles.log.restore();
-      } );
-
-      test( "should handle deleting files", () => {
-        watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] );
-
-        watchFiles._handleSingleFileUpdate( {
-          filePath: "foo.jpg",
-          fileUrl: sampleUrl( "foo.jpg" ),
-          status: "deleted",
+          ]);
         } );
 
-        assert.equal( watchFiles.watchedFileDeletedCallback.callCount, 1 );
-        assert.equal( watchFiles.managedFiles.length, 1);
-        assert.equal( watchFiles._managedFilesInError.length, 0);
+        test( "should handle deleting files", () => {
+          watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] );
+
+          watchFiles._handleSingleFileUpdate( {
+            filePath: "foo.jpg",
+            fileUrl: sampleUrl( "foo.jpg" ),
+            status: "deleted",
+          } );
+
+          assert.equal( watchFiles.watchedFileDeletedCallback.callCount, 1 );
+          assert.equal( watchFiles.managedFiles.length, 1);
+          assert.equal( watchFiles._managedFilesInError.length, 0);
+        } );
+
+        test( "should handle deleted file as warning", () => {
+          watchFiles._handleSingleFileError( {
+            status: "NOEXIST",
+            filePath: "baz.mp4",
+            fileUrl: sampleUrl( "baz.mp4" )
+          } );
+
+          assert.deepEqual( watchFiles.log.lastCall.args, [
+            "warning",
+            "file-not-found",
+            {
+              errorMessage: undefined,
+              errorDetail: undefined
+            },
+            {
+              storage: {
+                configuration: "storage file",
+                file_form: "mp4",
+                file_path: "baz.mp4",
+                local_url: sampleUrl( "baz.mp4" )
+              }
+            }
+          ]);
+        } );
+
       } );
+
     } );
 
     suite( "ordering", () => {


### PR DESCRIPTION
## Description
Logs file-not-exist as warning instead of error

## Motivation and Context
A lot of these entries are logged for image, and may be logged also for video. These refer to files that are deleted by a user on storage, but may still be referenced by presentations. It's not a component error if a user deletes a file, so this should be a warning instead of an error.

## How Has This Been Tested?
Manually tested using this presentation that points to a staged version of this component:
https://apps.risevision.com/templates/edit/74e6e489-e0b5-4e9a-a1f2-1f4adeb90578/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

This logs a warning instead of an error, as it can be verified here:
```
#StandardSQL
SELECT ts, level, event, event_details, template.name, template.version AS template_version, component.id, version AS component_version
FROM `client-side-events.Display_Events.events_test` 
WHERE DATE(ts) = "2019-09-11" -- search specific date
AND display_id = 'DTPNKPGM7X56'
--AND level IN ( 'error', 'warning', 'severe' )
AND event NOT IN ( 'PUD state', 'image-svg-usage', 'image-reset' )
ORDER BY ts DESC
```

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
    - Both manual and automated tests created
    - This is just the change for the library, so a simple rollback is needed to undo these changes.
    - README documentation updated.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support