### PR TITLE
Implement cache API fallback via localStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "prebuild": "eslint . && ./scripts/create_config.sh prod rise-element",

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -153,7 +153,7 @@ export const CacheMixin = dedupingMixin( base => {
           return cache.put( res.url || url, res );
         }).catch( err => {
           super.log( "warning", "cache put failed", { url: res.url || url }, err );
-        });        
+        });
       } else {
         return Promise.resolve();
       }

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -157,7 +157,7 @@ export const CacheMixin = dedupingMixin( base => {
         return this._getCache().then( cache => {
           return cache.put( response.url || url, response );
         }).catch( err => {
-          super.log( "warning", "cache put failed", { url: res.url || url, err });
+          super.log( "warning", "cache put failed", { url: response.url || url, err });
         });
       } else {
         return Promise.resolve();

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -25,7 +25,8 @@ export const CacheMixin = dedupingMixin( base => {
           const cacheObject = {
             headers: [],
             status: response.status,
-            statusText: response.statusText
+            statusText: response.statusText,
+            url: response.url
           };
 
           response.headers.forEach(( val, key ) => {
@@ -46,6 +47,10 @@ export const CacheMixin = dedupingMixin( base => {
               headers: cacheObject.headers
             },
             response = new Response( new Blob([ cacheObject.text ]), init );
+
+          if ( cacheObject.url ) {
+            Object.defineProperty( response, "url", { value: cacheObject.url });
+          }
 
           return response;
         },
@@ -147,12 +152,12 @@ export const CacheMixin = dedupingMixin( base => {
       }
     }
 
-    putCache( res, url ) {
+    putCache( response, url ) {
       if ( this._caches ) {
         return this._getCache().then( cache => {
-          return cache.put( res.url || url, res );
+          return cache.put( response.url || url, response );
         }).catch( err => {
-          super.log( "warning", "cache put failed", { url: res.url || url }, err );
+          super.log( "warning", "cache put failed", { url: response.url || url }, err );
         });
       } else {
         return Promise.resolve();

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -28,9 +28,9 @@ export const CacheMixin = dedupingMixin( base => {
             statusText: response.statusText
           };
 
-          for ( let p of response.headers.entries()) {
-            cacheObject.headers.push( p );
-          }
+          response.headers.forEach(( val, key ) => {
+            cacheObject.headers.push([ key, val ]);
+          })
 
           return response.clone().text().then( text => {
             cacheObject.text = text;

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -9,11 +9,94 @@ export const CacheMixin = dedupingMixin( base => {
     },
     cacheBase = LoggerMixin( base );
 
+  class LocalStorageFallback {
+    open( namespace ) {
+      const getFullKey = key => {
+          return namespace + key;
+        },
+        tryParse = text => {
+          try {
+            return JSON.parse( text );
+          } catch ( e ) {
+            return {};
+          }
+        },
+        cacheToResponse = response => {
+          const cacheObject = {
+            headers: [],
+            status: response.status,
+            statusText: response.statusText
+          };
+
+          for ( let p of response.headers.entries()) {
+            cacheObject.headers.push( p );
+          }
+
+          return response.clone().text().then( text => {
+            cacheObject.text = text;
+
+            return JSON.stringify( cacheObject );
+          });
+        },
+        responseToCache = text => {
+          const cacheObject = tryParse( text ),
+            init = {
+              status: cacheObject.status,
+              statusText: cacheObject.statusText,
+              headers: cacheObject.headers
+            },
+            response = new Response( new Blob([ cacheObject.text ]), init );
+
+          return response;
+        },
+        cacheMock = {
+          keys: () => {
+            const keys = [];
+
+            for ( let i = 0, len = localStorage.length; i < len; ++i ) {
+              if ( localStorage.key( i ).startsWith( namespace )) {
+                const key = localStorage.key( i ).slice( namespace.length );
+
+                keys.push( key );
+              }
+            }
+
+            return Promise.resolve( keys );
+          },
+          match: ( key ) => {
+            const item = localStorage.getItem( getFullKey( key ));
+
+            if ( item ) {
+              let response = responseToCache( item );
+
+              return Promise.resolve( response );
+            } else {
+              return Promise.reject();
+            }
+          },
+          delete: ( key ) => {
+            localStorage.removeItem( getFullKey( key ));
+          },
+          put: ( key, value ) => {
+            cacheToResponse( value ).then( text => {
+              localStorage.setItem( getFullKey( key ), text );
+            });
+          }
+        };
+
+      return Promise.resolve( cacheMock );
+    }
+  }
+
   class Cache extends cacheBase {
     constructor() {
       super();
 
       this.cacheConfig = Object.assign({}, CACHE_CONFIG );
+
+      if ( !( window.caches && window.caches.open )) {
+        window.caches = new LocalStorageFallback();
+      }
     }
 
     initCache( cacheConfig ) {
@@ -26,7 +109,7 @@ export const CacheMixin = dedupingMixin( base => {
       if ( window.caches && window.caches.open ) {
         return caches.open( this.cacheConfig.name );
       } else {
-        super.log( "warning", "cache API not available" );
+        super.log( "warning", "cache API not available", true );
 
         return Promise.reject();
       }
@@ -53,7 +136,7 @@ export const CacheMixin = dedupingMixin( base => {
             });
           });
         });
-      });
+      }).catch(() => {});
     }
 
     putCache( res, url ) {
@@ -65,7 +148,7 @@ export const CacheMixin = dedupingMixin( base => {
     }
 
     getCache( url ) {
-      var _cache;
+      let _cache;
 
       return this._getCache().then( cache => {
         _cache = cache;
@@ -75,9 +158,11 @@ export const CacheMixin = dedupingMixin( base => {
           return Promise.resolve( response );
         } else if ( !this._isResponseExpired( response, this.cacheConfig.expiry )) {
           return Promise.reject( response );
-        } else {
+        } else if ( _cache ) {
           response && _cache.delete( url );
 
+          return Promise.reject();
+        } else {
           return Promise.reject();
         }
       });

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -146,11 +146,15 @@ export const CacheMixin = dedupingMixin( base => {
     }
 
     putCache( res, url ) {
-      return this._getCache().then( cache => {
-        return cache.put( res.url || url, res );
-      }).catch( err => {
-        super.log( "warning", "cache put failed", { url: res.url || url }, err );
-      });
+      if ( this._caches ) {
+        return this._getCache().then( cache => {
+          return cache.put( res.url || url, res );
+        }).catch( err => {
+          super.log( "warning", "cache put failed", { url: res.url || url }, err );
+        });        
+      } else {
+        return Promise.resolve();
+      }
     }
 
     getCache( url ) {

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -118,7 +118,7 @@ export const FetchMixin = dedupingMixin( base => {
         this._requestRetryCount = 0;
 
         if ( err && err.isOffline ) {
-          super.log( "warning", "client offline", { error: err ? err.message : null }, true );
+          super.log( "warning", "client offline", { error: err ? err.message : null });
         } else {
           super.log( "error", "request error", { error: err ? err.message : null });
         }

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -118,7 +118,7 @@ export const FetchMixin = dedupingMixin( base => {
         this._requestRetryCount = 0;
 
         if ( err && err.isOffline ) {
-          super.log( "error", "client offline", { error: err ? err.message : null });
+          super.log( "warning", "client offline", { error: err ? err.message : null }, true );
         } else {
           super.log( "error", "request error", { error: err ? err.message : null });
         }

--- a/test/index.html
+++ b/test/index.html
@@ -16,6 +16,7 @@
     "unit/rise-element.html",
     "unit/logger-mixin.html",
     "unit/cache-mixin.html",
+    "unit/cache-mixin-fallback.html",
     "unit/fetch-mixin.html",
     "unit/valid-files-mixin.html",
     "unit/watch-files-mixin.html"

--- a/test/unit/cache-mixin-fallback.html
+++ b/test/unit/cache-mixin-fallback.html
@@ -1,0 +1,189 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script src="../../node_modules/chai/chai.js"></script>
+  <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+
+</head>
+<body>
+
+<script type="text/javascript">
+  RisePlayerConfiguration = {
+    Logger: {
+      info: () => {},
+      warning: () => {},
+      error: () => {}
+    }
+  };
+
+  function createLocalStorageStub() {
+    localStorage.setItem("rise-common-componentkey1", "{\"text\":\"123\", \"headers\":[[\"date\", \"" + new Date() + "\"]]}");
+    localStorage.setItem("rise-common-componentkey2", "{\"text\":\"123\",\"headers\":[[\"date\", \"" + new Date(Date.now() - 1000 * 60 * 60 * 3) + "\"]]}");
+    localStorage.setItem("rise-common-componentkey3", "{\"text\":\"123\",\"headers\":[[\"date\", \"" + new Date('1980-01-01') + "\"]]}");
+
+    sinon.spy(localStorage, "getItem");
+    sinon.spy(localStorage, "removeItem");
+    sinon.spy(localStorage, "setItem");
+  }
+</script>
+
+<script type="module">
+  import * as cacheModule from '../../src/cache-mixin.js';
+
+  suite("cache", () => {
+    let cache, logger;
+    let windowCachesOpen;
+
+    setup(()=>{
+      let Cache = cacheModule.CacheMixin(class {});
+
+      createLocalStorageStub();
+      windowCachesOpen = caches.open;
+      caches.open = undefined;
+
+      cache = new Cache();
+
+      sinon.spy(cache._caches, "open");
+
+      logger = cache.__proto__.__proto__;
+      sinon.stub(logger, "log");
+    });
+
+    teardown(()=>{
+      sinon.restore();
+      caches.open = windowCachesOpen;
+    });
+
+    suite( "init", () => {
+      test( "should cache with defaults", () => {
+        cache.initCache();
+    
+        assert.isTrue( cache._caches.open.calledWith( "cache-mixin" ) );
+      });
+    
+      test( "should init cache", () => {
+        cache.initCache({
+          name: "rise-common-component",
+        });
+      
+        assert.isTrue( cache._caches.open.calledWith( "rise-common-component" ) );
+      });
+    });
+
+    suite("deleteExpiredCache", () => {
+    
+      test( "should clear old cache entries on init", done => {
+        cache.initCache();
+    
+        setTimeout(() => {
+          assert.isFalse( localStorage.removeItem.calledWith('rise-common-componentkey1'));
+          assert.isFalse( localStorage.removeItem.calledWith('rise-common-componentkey2'));
+          assert.isTrue( localStorage.removeItem.calledWith('rise-common-componentkey3'));
+    
+          done();
+        }, 10);
+      });
+    
+      test( "should not clear old cache entries on init if expiry === -1", done => {
+        cache.initCache({ expiry: -1 });
+    
+        setTimeout(() => {
+          assert.isFalse( localStorage.removeItem.called );
+    
+          done();
+        }, 10);
+      });
+    });
+
+    suite("get", () => {
+      test( "should reject promise if key is not found", done => {
+        cache.getCache().then(() => {
+          done("error");
+        }).catch(() => {
+          assert.isTrue(true);
+          done();
+        });
+      });
+
+      test( "should send cached data if cache is valid", done => {
+        const expiration = new Date();
+        const cacheString = JSON.stringify({"headers":[["content-type","text/plain;charset=UTF-8"],["date",expiration]],"status":200,"statusText":"","text":"<report><observation temperature=\"12\"/><location/></report>"})
+        localStorage.setItem("cache-mixinkey3", cacheString);
+
+        cache.getCache("key3").then( data => {
+          assert.isTrue( data instanceof Response );
+
+          done();
+        }).catch( error => {
+          done(error);
+        });
+      });
+
+      test( "should not delete expired cached data if expiry is valid", done => {
+        const expiration = new Date(Date.now() - 1000 * 60 * 60 * 3);
+        const cacheString = JSON.stringify({"headers":[["content-type","text/plain;charset=UTF-8"],["date",expiration]],"status":200,"statusText":"","text":"<report><observation temperature=\"12\"/><location/></report>"})
+        localStorage.setItem("cache-mixinkey3", cacheString);
+
+        cache.getCache("key3").then(() => {
+          done("error");
+        }).catch((data) => {
+          assert.isFalse( localStorage.removeItem.called );
+          assert.isTrue( data instanceof Response );
+
+          done();
+        });
+      });
+
+      test( "should delete expired cached data", done => {
+        const expiration = new Date('1980-01-01');
+        const cacheString = JSON.stringify({"headers":[["content-type","text/plain;charset=UTF-8"],["date",expiration]],"status":200,"statusText":"","text":"<report><observation temperature=\"12\"/><location/></report>"})
+        localStorage.setItem("cache-mixinkey3", cacheString);
+
+        cache.getCache("key3").then(() => {
+          done("error");
+        }).catch(() => {
+          assert.isTrue( localStorage.removeItem.called );
+
+          done();
+        });
+      });
+    });
+
+    suite("put", () => {
+      test("should store url as key and the object", done => {
+        var response = new Response("<report><observation temperature=\"12\"/><location/></report>",{headers:{date: new Date('1980-01-01')}})
+        cache.putCache( response );
+
+        setTimeout(() => {
+          // Note: Can't actually set the URL when constructing a Response object
+          assert.isTrue( localStorage.setItem.calledWith( 'cache-mixinundefined', JSON.stringify({"headers":[["content-type","text/plain;charset=UTF-8"],["date","Mon Dec 31 1979 19:00:00 GMT-0500 (Eastern Standard Time)"]],"status":200,"statusText":"","text":"<report><observation temperature=\"12\"/><location/></report>"}) ));
+
+          done();
+        }, 10);
+      });
+
+      test("should store url as key and the object when url provided as function parameter", done => {
+        var response = new Response("<report><observation temperature=\"12\"/><location/></report>",{headers:{date: new Date('1980-01-01')}})
+        cache.putCache( response , "key3" );
+
+        setTimeout(() => {
+          assert.isTrue( localStorage.setItem.calledWith( 'cache-mixinkey3', sinon.match.string ));
+
+          done();
+        }, 10);
+      });
+    });
+
+  });
+</script>
+
+</body>
+</html>

--- a/test/unit/cache-mixin-fallback.html
+++ b/test/unit/cache-mixin-fallback.html
@@ -164,14 +164,14 @@
 
         setTimeout(() => {
           // Note: Can't actually set the URL when constructing a Response object
-          assert.isTrue( localStorage.setItem.calledWith( 'cache-mixinundefined', JSON.stringify({"headers":[["content-type","text/plain;charset=UTF-8"],["date","315532800000"]],"status":200,"statusText":"","text":"<report><observation temperature=\"12\"/><location/></report>"}) ));
+          assert.isTrue( localStorage.setItem.calledWith( 'cache-mixinundefined', JSON.stringify({"headers":[["content-type","text/plain;charset=UTF-8"],["date","315532800000"]],"status":200,"statusText":"","url":"","text":"<report><observation temperature=\"12\"/><location/></report>"}) ));
 
           done();
         }, 10);
       });
 
       test("should store url as key and the object when url provided as function parameter", done => {
-        var response = new Response("<report><observation temperature=\"12\"/><location/></report>",{headers:{date: new Date('1980-01-01')}})
+        var response = new Response("<report><observation temperature=\"12\"/><location/></report>",{headers:{date: (new Date('1980-01-01')).getTime()}})
         cache.putCache( response , "key3" );
 
         setTimeout(() => {

--- a/test/unit/cache-mixin-fallback.html
+++ b/test/unit/cache-mixin-fallback.html
@@ -105,7 +105,7 @@
 
     suite("get", () => {
       test( "should reject promise if key is not found", done => {
-        cache.getCache().then(() => {
+        cache.getCache("missingKey").then(() => {
           done("error");
         }).catch(() => {
           assert.isTrue(true);
@@ -116,9 +116,9 @@
       test( "should send cached data if cache is valid", done => {
         const expiration = new Date();
         const cacheString = JSON.stringify({"headers":[["content-type","text/plain;charset=UTF-8"],["date",expiration]],"status":200,"statusText":"","text":"<report><observation temperature=\"12\"/><location/></report>"})
-        localStorage.setItem("cache-mixinkey3", cacheString);
+        localStorage.setItem("cache-mixinkey4", cacheString);
 
-        cache.getCache("key3").then( data => {
+        cache.getCache("key4").then( data => {
           assert.isTrue( data instanceof Response );
 
           done();
@@ -130,9 +130,9 @@
       test( "should not delete expired cached data if expiry is valid", done => {
         const expiration = new Date(Date.now() - 1000 * 60 * 60 * 3);
         const cacheString = JSON.stringify({"headers":[["content-type","text/plain;charset=UTF-8"],["date",expiration]],"status":200,"statusText":"","text":"<report><observation temperature=\"12\"/><location/></report>"})
-        localStorage.setItem("cache-mixinkey3", cacheString);
+        localStorage.setItem("cache-mixinkey4", cacheString);
 
-        cache.getCache("key3").then(() => {
+        cache.getCache("key4").then(() => {
           done("error");
         }).catch((data) => {
           assert.isFalse( localStorage.removeItem.called );
@@ -145,9 +145,9 @@
       test( "should delete expired cached data", done => {
         const expiration = new Date('1980-01-01');
         const cacheString = JSON.stringify({"headers":[["content-type","text/plain;charset=UTF-8"],["date",expiration]],"status":200,"statusText":"","text":"<report><observation temperature=\"12\"/><location/></report>"})
-        localStorage.setItem("cache-mixinkey3", cacheString);
+        localStorage.setItem("cache-mixinkey4", cacheString);
 
-        cache.getCache("key3").then(() => {
+        cache.getCache("key4").then(() => {
           done("error");
         }).catch(() => {
           assert.isTrue( localStorage.removeItem.called );

--- a/test/unit/cache-mixin-fallback.html
+++ b/test/unit/cache-mixin-fallback.html
@@ -159,12 +159,12 @@
 
     suite("put", () => {
       test("should store url as key and the object", done => {
-        var response = new Response("<report><observation temperature=\"12\"/><location/></report>",{headers:{date: new Date('1980-01-01')}})
+        var response = new Response("<report><observation temperature=\"12\"/><location/></report>",{headers:{date: (new Date('1980-01-01')).getTime()}})
         cache.putCache( response );
 
         setTimeout(() => {
           // Note: Can't actually set the URL when constructing a Response object
-          assert.isTrue( localStorage.setItem.calledWith( 'cache-mixinundefined', JSON.stringify({"headers":[["content-type","text/plain;charset=UTF-8"],["date","Mon Dec 31 1979 19:00:00 GMT-0500 (Eastern Standard Time)"]],"status":200,"statusText":"","text":"<report><observation temperature=\"12\"/><location/></report>"}) ));
+          assert.isTrue( localStorage.setItem.calledWith( 'cache-mixinundefined', JSON.stringify({"headers":[["content-type","text/plain;charset=UTF-8"],["date","315532800000"]],"status":200,"statusText":"","text":"<report><observation temperature=\"12\"/><location/></report>"}) ));
 
           done();
         }, 10);

--- a/test/unit/cache-mixin.html
+++ b/test/unit/cache-mixin.html
@@ -75,7 +75,7 @@
 
     suite( "init", () => {
       test( "should cache with defaults", () => {
-        cache.getCache();
+        cache.initCache();
 
         assert.isTrue( caches.open.calledWith( "cache-mixin" ) );
       });

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -310,7 +310,7 @@
 
           fetchMixin._handleFetchError( { message: "error", isOffline: true } );
 
-          assert.deepEqual(loggerMixin.log.getCall(0).args, ["warning", "client offline", {error: "error"}, true]);
+          assert.deepEqual(loggerMixin.log.getCall(0).args, ["warning", "client offline", {error: "error"}]);
 
           assert.isTrue( handleError.called );
         });

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -310,7 +310,7 @@
 
           fetchMixin._handleFetchError( { message: "error", isOffline: true } );
 
-          assert.deepEqual(loggerMixin.log.getCall(0).args, ["error", "client offline", {error: "error"}]);
+          assert.deepEqual(loggerMixin.log.getCall(0).args, ["warning", "client offline", {error: "error"}, true]);
 
           assert.isTrue( handleError.called );
         });


### PR DESCRIPTION
## Description
Implement `cache` API fallback via `localStorage`

Improved error catching
Log `cache` and `localStorage` availability
Prevent extra logging when caching is not available

## Motivation and Context
Fix for https://github.com/Rise-Vision/rise-common-component/issues/21

This basically provides a fallback for `cache` as it is not available in http. The fallback uses `localStorage`

## How Has This Been Tested?
Validated via rise-data-weather on both local environment and Chrome OS

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
