### PR TITLE
Fix log call to correctly include err object in event_details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.0.12",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "prebuild": "eslint . && ./scripts/create_config.sh prod rise-element",

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -60,7 +60,7 @@ export const CacheMixin = dedupingMixin( base => {
       return this._getCache().then( cache => {
         return cache.put( res.url || url, res );
       }).catch( err => {
-        super.log( "warning", "cache put failed", { url: res.url || url }, err );
+        super.log( "warning", "cache put failed", { url: res.url || url, err });
       });
     }
 


### PR DESCRIPTION
## Description
When `cache.put` fails, ensure the log params are structured correctly to include the `err` object as part of the `event_details`

## Motivation and Context
All _cache put failed_ logs are not including the `err` object as the `err` has been treated as additional fields which is incorrect. 

This change now ensures it will be included within `event_details` field. 

## How Has This Been Tested?
Tested locally via forcing a bad response to the `putCache` call via local financial component on ChrOS player

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manually tested
  - Will validate on production by monitoring logs of a display reporting issue which will be rebooted after this is deployed. 
  - Rollback involves reverting to previous version of rise-common-component in financial component and re-deploying. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- Documentation, notifying Support, automated tests
