### PR TITLE
Feature/avoid retries for status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,21 @@ To use the `fetchMixin`, you can simply call:
 
 The functionality will retrieve the data from the URL, and return it via the `_handleResponse` callback. In case an error is received, and after the retry count has been surpassed, the `_handleError` function will be called.
 
+### Avoid retries depending on HTTP status code
+
+The response status code of a service is an indicative of the problem. In some cases, the status code indicates that a request should not be retried, or at least should not be retried right away. To avoid the retry loop and pass directly to cooldown interval, the `avoidRetriesForStatusCodes` parameer can be used:
+
+```
+{
+  retry: 1000 * 60,
+  cooldown: 1000 * 60 * 10,
+  refresh: 1000 * 60 * 60,
+  count: 5,
+  avoidRetriesForStatusCodes: [400, 403, 429]
+}
+```
+
+In the previous example configuration, the HTTP status codes 400 ( bad request ), 403 ( forbidden ) and 429 ( too many requests ) won't be attempted immediately after the retry period, but only after some cooldown period.
 
 #### Fetch Example
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The functionality will retrieve the data from the URL, and return it via the `_h
 
 ### Avoid retries depending on HTTP status code
 
-The response status code of a service is an indicative of the problem. In some cases, the status code indicates that a request should not be retried, or at least should not be retried right away. To avoid the retry loop and pass directly to cooldown interval, the `avoidRetriesForStatusCodes` parameer can be used:
+The HTTP response status code of a service invocation is indicative of any problem that happens when invoking that service. In some cases, the status code indicates that a request should not be retried, or at least should not be retried right away. To avoid the retry loop, and go directly to cooldown interval, the `avoidRetriesForStatusCodes` parameer can be used:
 
 ```
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -280,6 +280,10 @@
         fetchMixin._requestData().then(() => {
           assert.isTrue( fetchMixin._handleFetchError.called );
 
+          const error = fetchMixin._handleFetchError.lastCall.args[0];
+          assert( error );
+          assert.equal( error.status, 500 );
+
           done();
         });
       });
@@ -372,6 +376,32 @@
           assert.deepEqual(loggerMixin.log.getCall(0).args, ["warning", "client offline", {error: "error"}]);
 
           assert.isTrue( handleError.called );
+        });
+
+        test( "should not retry if status code is excluded", () => {
+          sinon.stub(fetchMixin, "_refresh");
+
+          fetchMixin.fetchConfig.avoidRetriesForStatusCodes = [400];
+          fetchMixin._requestRetryCount = 0;
+
+          fetchMixin._handleFetchError( { status: 400, message: "error", isOffline: false } );
+
+          assert.deepEqual(loggerMixin.log.getCall(0).args, ["error", "request error", {error: "error"}]);
+          assert.isTrue( handleError.called );
+          assert.equal( fetchMixin._requestRetryCount, 0 );
+        });
+
+        test( "should retry if status code is excluded but is offline", () => {
+          sinon.stub(fetchMixin, "_refresh");
+
+          fetchMixin.fetchConfig.avoidRetriesForStatusCodes = [400];
+          fetchMixin._requestRetryCount = 0;
+
+          fetchMixin._handleFetchError( { status: 400, message: "error", isOffline: true } );
+
+          assert.isFalse( loggerMixin.log.called );
+          assert.isFalse( handleError.called );
+          assert.equal( fetchMixin._requestRetryCount, 1 );
         });
 
         test( "should debounce existing cooldown", () => {


### PR DESCRIPTION
## Description
Do not do immediate retries for some HTTP status codes.

Related PR: https://github.com/Rise-Vision/rise-data-twitter/pull/8

## Motivation and Context
Some return status codes of twitter-service are related to problems that don't require immediate retries:

- 429 to many requests - is related to quota issues. We should  wait until Twitter API's quota window is over before retrying again. The cooldown period would be set to the duration of the quota window for this case.
- 403 forbidden - is related to invalid credentials. It does not make sense to retry until credentials are created. Waiting some cooldown period may be desired in this case.
- 400 bad request - is related to a badly created request. The service invocation should never result in this error, and must be corrected in the component. Avoiding retries will reduce traffic in this case.

As fetch-mixin is generic, a configuration array with status code can be set by an implementing class to exclude particular error codes from the retry mechanism. Current implementors of fetch-mixin will continue to behave as usual ( rise-data-weather, rise-data-rss ).

## How Has This Been Tested?
This branch or rise-data-twitter implements this:
https://github.com/Rise-Vision/rise-data-twitter/compare/e2e/handle-http-errors?expand=1

And then manually tested with schedules pointing a template with this Twitter component version:
https://github.com/Rise-Vision/html-template-library/compare/example-twitter-component/staging/test?expand=1

Schedule:
https://apps.risevision.com/schedules/details/42dc0db9-07e9-453c-9a1f-6dc38cb15f9c?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

Scenarios

- Valid username and credentials work ok.
- Invalid credentials sends a 403 error, which result in immediate error handling:
![immediate-error](https://user-images.githubusercontent.com/33162690/76010748-0e5b4c80-5ed9-11ea-9735-513dbfb6683c.png)

- Invalid username sends a 500 error, which results in retries ( error gets handled after some time, when retries stop )
![error-with-retries](https://user-images.githubusercontent.com/33162690/76010827-2763fd80-5ed9-11ea-85bc-915fbed4a228.png)

Also unit tests were created.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     As this is a library, it won't affect existing components. It can be relased anytime.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support.
