### PR TITLE
Feature/refresh considering cache headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ The HTTP response status code of a service invocation is indicative of any probl
 
 In the previous example configuration, the HTTP status codes 400 ( bad request ), 403 ( forbidden ) and 429 ( too many requests ) won't be attempted immediately after the retry period, but only after some cooldown period.
 
-### Calculate expiration based on Cache-Control header max-age value
+### Calculate expiration based on *Cache-Control* header *max-age* value
 
-Instead of relying in a fixed expiration, fetch-mixin can calculate it's refresh value based on `Cache-Control` header expiration value. To enable this behavior the `refreshFromCacheControlHeader` parameter can be used:
+Instead of relying in a fixed expiration, fetch-mixin can calculate its refresh value based on `Cache-Control` header expiration value. To enable this behavior the `refreshFromCacheControlHeader` parameter can be used:
 
 ```
 {
@@ -221,9 +221,9 @@ Instead of relying in a fixed expiration, fetch-mixin can calculate it's refresh
 }
 ```
 
-This parameter is disabled by default. When enabled, it will calculate a refresh value based on the given expiration value plus a random small interval of time ( no greater than the cooldown parameter ). The extra padding is added to avoid a large number of displays hitting a service at exactly the same time when all their expirations complete.
+This parameter is disabled by default. When enabled, it will calculate a refresh value based on the given expiration value plus a random interval of time no greater than the cooldown parameter. This extra small interval is added to avoid a large number of displays hitting a service at exactly the same time when all their refresh intervals complete.
 
-If the service response contains no Cache-Control header, or if it contains no max-age value, the default `refresh` value will be used.
+If the service response contains no Cache-Control header, or if it contains no `max-age` value, the default `refresh` value will be used.
 
 #### Fetch Example
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,21 @@ The HTTP response status code of a service invocation is indicative of any probl
 
 In the previous example configuration, the HTTP status codes 400 ( bad request ), 403 ( forbidden ) and 429 ( too many requests ) won't be attempted immediately after the retry period, but only after some cooldown period.
 
+### Calculate expiration based on Cache-Control header max-age value
+
+Instead of relying in a fixed expiration, fetch-mixin can calculate it's refresh value based on `Cache-Control` header expiration value. To enable this behavior the `refreshFromCacheControlHeader` parameter can be used:
+
+```
+{
+  refresh: 1000 * 60 * 60,
+  refreshFromCacheControlHeader: true
+}
+```
+
+This parameter is disabled by default. When enabled, it will calculate a refresh value based on the given expiration value plus a random small interval of time ( no greater than the cooldown parameter ). The extra padding is added to avoid a large number of displays hitting a service at exactly the same time when all their expirations complete.
+
+If the service response contains no Cache-Control header, or if it contains no max-age value, the default `refresh` value will be used.
+
 #### Fetch Example
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -121,10 +121,9 @@ export const FetchMixin = dedupingMixin( base => {
 
           if ( match ) {
             const expirationInSeconds = Number( match[ 1 ]) * 1000;
-            const smallExtraInterval = this.fetchConfig.retry;
             const randomExtraInterval = Math.floor( Math.random() * this.fetchConfig.cooldown );
 
-            return expirationInSeconds + smallExtraInterval + randomExtraInterval;
+            return expirationInSeconds + randomExtraInterval;
           }
         }
       }

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -1,3 +1,5 @@
+/* eslint-disable one-var */
+
 import { timeOut } from "@polymer/polymer/lib/utils/async.js";
 import { Debouncer } from "@polymer/polymer/lib/utils/debounce.js";
 import { dedupingMixin } from "@polymer/polymer/lib/utils/mixin.js";
@@ -9,6 +11,7 @@ export const FetchMixin = dedupingMixin( base => {
       cooldown: 1000 * 60 * 10,
       refresh: 1000 * 60 * 60,
       avoidRetriesForStatusCodes: [],
+      refreshFromCacheControlHeader: false,
       count: 5
     },
     fetchBase = LoggerMixin( base );
@@ -103,7 +106,30 @@ export const FetchMixin = dedupingMixin( base => {
     _processData( resp ) {
       this.processData && this.processData( resp );
 
-      this._refresh( this.fetchConfig.refresh );
+      const refreshInterval = this._getRefreshInterval( resp );
+
+      console.log( `Refreshing in ${ refreshInterval }` ); // eslint-disable-line no-console
+      this._refresh( refreshInterval );
+    }
+
+    _getRefreshInterval( resp ) {
+      if ( resp && !resp.isCached && !resp.isOffline && this.fetchConfig.refreshFromCacheControlHeader ) {
+        const header = resp.headers && resp.headers.get( "Cache-Control" );
+
+        if ( header ) {
+          const match = header.match( /max-age=(\d+)/ );
+
+          if ( match ) {
+            const expirationInSeconds = Number( match[ 1 ]) * 1000;
+            const smallExtraInterval = this.fetchConfig.retry;
+            const randomExtraInterval = Math.floor( Math.random() * this.fetchConfig.cooldown );
+
+            return expirationInSeconds + smallExtraInterval + randomExtraInterval;
+          }
+        }
+      }
+
+      return this.fetchConfig.refresh;
     }
 
     _logData( cached ) {

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -108,7 +108,6 @@ export const FetchMixin = dedupingMixin( base => {
 
       const refreshInterval = this._getRefreshInterval( resp );
 
-      console.log( `Refreshing in ${ refreshInterval }` ); // eslint-disable-line no-console
       this._refresh( refreshInterval );
     }
 

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -19,6 +19,10 @@
 <script type="module">
   import * as fetchModule from '../../src/fetch-mixin.js';
 
+  const DEFAULT_COOLDOWN = 1000 * 60 * 10;
+  const DEFAULT_REFRESH = 1000 * 60 * 60;
+  const DEFAULT_RETRY = 1000 * 60;
+
   suite("fetch", () => {
     let elementMixin, fetchMixin, cacheMixin, loggerMixin, handleResponse, handleError;
 
@@ -38,9 +42,9 @@
       handleError = sinon.stub();
       fetchMixin.fetchConfig = {};
       fetchMixin.initFetch({
-        retry: 1000 * 60,
-        cooldown: 1000 * 60 * 10,
-        refresh: 1000 * 60 * 60,
+        retry: DEFAULT_RETRY,
+        cooldown: DEFAULT_COOLDOWN,
+        refresh: DEFAULT_REFRESH,
         count: 5
       }, handleResponse, handleError );
     });
@@ -73,7 +77,7 @@
         fetchMixin.initFetch();
 
         assert.isTrue( cacheMixin.initCache.called );
-        assert.deepEqual( cacheMixin.initCache.getCall(0).args[0], { refresh: ( 1000 * 60 * 60 - 5 * 1000 )} );
+        assert.deepEqual( cacheMixin.initCache.getCall(0).args[0], { refresh: ( DEFAULT_REFRESH - 5 * 1000 )} );
       });
 
       test( "should init cache refresh with the default value if under 10s", () => {
@@ -322,7 +326,7 @@
 
           assert.isTrue( fetchMixin._requestRetryCount === 1 );
           assert.isTrue( fetchMixin._refresh.called );
-          assert.isTrue( fetchMixin._refresh.calledWith(1000 * 60) );
+          assert.isTrue( fetchMixin._refresh.calledWith(DEFAULT_RETRY) );
         });
 
         test( "should debounce and call _getData after interval", () => {
@@ -348,7 +352,7 @@
 
           assert.equal( fetchMixin._requestRetryCount, 0 );
           assert.isTrue( fetchMixin._refresh.called );
-          assert.isTrue( fetchMixin._refresh.calledWith(1000 * 60 * 10) );
+          assert.isTrue( fetchMixin._refresh.calledWith(DEFAULT_COOLDOWN) );
 
           assert.deepEqual( loggerMixin.log.getCall(0).args, ["error", "request error", {error: null}] );
 
@@ -496,7 +500,84 @@
         fetchMixin._processData();
 
         assert.isTrue( fetchMixin._refresh.called );
-        assert.isTrue( fetchMixin._refresh.calledWith(60 * 60 * 1000));
+        assert.isTrue( fetchMixin._refresh.calledWith(DEFAULT_REFRESH));
+      });
+    });
+
+    suite( "_getRefreshInterval", () => {
+      test( "get regular refresh interval when refreshFromCacheControlHeader parameter is not set", () => {
+        const interval = fetchMixin._getRefreshInterval({});
+
+        assert.equal( interval, DEFAULT_REFRESH );
+      });
+
+      test( "get refresh interval based on Cache-Control expiration", () => {
+        fetchMixin.fetchConfig.refreshFromCacheControlHeader = true;
+
+        const interval = fetchMixin._getRefreshInterval({
+          headers: {
+            get: () => "private, max-age=100"
+          }
+        });
+
+        const baseInterval = 100 * 1000;
+        const minRefresh = baseInterval + DEFAULT_RETRY;
+        const maxRefresh = minRefresh + DEFAULT_COOLDOWN;
+
+        assert.isTrue( interval >= minRefresh );
+        assert.isTrue( interval <= maxRefresh );
+      });
+
+      test( "get regular refresh interval when offline", () => {
+        fetchMixin.fetchConfig.refreshFromCacheControlHeader = true;
+
+        const interval = fetchMixin._getRefreshInterval({
+          isOffline: true,
+          headers: {
+            get: () => "private, max-age=100"
+          }
+        });
+
+        assert.equal( interval, DEFAULT_REFRESH );
+      });
+
+      test( "get regular refresh interval when cached", () => {
+        fetchMixin.fetchConfig.refreshFromCacheControlHeader = true;
+
+        const interval = fetchMixin._getRefreshInterval({
+          isCached: true,
+          headers: {
+            get: () => "private, max-age=100"
+          }
+        });
+
+        assert.equal( interval, DEFAULT_REFRESH );
+      });
+
+      test( "get regular refresh interval when there is no Cache-Control header", () => {
+        fetchMixin.fetchConfig.refreshFromCacheControlHeader = true;
+
+        const interval = fetchMixin._getRefreshInterval({
+          isCached: true,
+          headers: {
+            get: () => null
+          }
+        });
+
+        assert.equal( interval, DEFAULT_REFRESH );
+      });
+
+      test( "get regular refresh interval when Cache-Control header contains no expiration", () => {
+        fetchMixin.fetchConfig.refreshFromCacheControlHeader = true;
+
+        const interval = fetchMixin._getRefreshInterval({
+          isCached: true,
+          headers: {
+            get: () => "private"
+          }
+        });
+
+        assert.equal( interval, DEFAULT_REFRESH );
       });
     });
 

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -513,19 +513,21 @@
 
       test( "get refresh interval based on Cache-Control expiration", () => {
         fetchMixin.fetchConfig.refreshFromCacheControlHeader = true;
-
-        const interval = fetchMixin._getRefreshInterval({
+        const response = {
           headers: {
             get: () => "private, max-age=100"
           }
-        });
+        };
 
-        const baseInterval = 100 * 1000;
-        const minRefresh = baseInterval + DEFAULT_RETRY;
-        const maxRefresh = minRefresh + DEFAULT_COOLDOWN;
+        for ( var i = 0; i < 100; i++ ) {
+          const interval = fetchMixin._getRefreshInterval( response );
 
-        assert.isTrue( interval >= minRefresh );
-        assert.isTrue( interval <= maxRefresh );
+          const minRefresh = 100 * 1000;
+          const maxRefresh = minRefresh + DEFAULT_COOLDOWN;
+
+          assert.isTrue( interval >= minRefresh );
+          assert.isTrue( interval <= maxRefresh );
+        }
       });
 
       test( "get regular refresh interval when offline", () => {


### PR DESCRIPTION
## Description
Calculate refresh interval dynamically based on Cache-Config header.

Related PR: https://github.com/Rise-Vision/rise-data-twitter/pull/9

## Motivation and Context
Twitter-service will be able to report the expiration interval of a given timeline. Based on this, we can avoid unnecessary requests to the server by using that value ( if provided ) to request new values. This is enabled by an additional parameter that is disabled by default, so current implementors of fetch-mixin won't be affected by this change.

## How Has This Been Tested?
This was implemented by rise-data-twitter on this branch:
https://github.com/Rise-Vision/rise-data-twitter/compare/staging/refresh-considering-cache-headers?expand=1

And ran on a template using this schedule:
https://apps.risevision.com/schedules/details/42dc0db9-07e9-453c-9a1f-6dc38cb15f9c?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

As caching is still not implemented in twitter-service, this branch that returns an arbitrary value for Cache-Control header was created and staged:

https://github.com/Rise-Vision/twitter-service/compare/feature/send-expiration-headers?expand=1

A debug version of this branch was created so we could see the caculated expirations to happen regularly on the log file:

![refresh](https://user-images.githubusercontent.com/33162690/76028851-08756380-5ef9-11ea-85ed-90cd585080e7.png)

Also, unit tests were added.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - This is a library, so no risk of releasing on Friday
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support.
