### PR TITLE
Feature/log as warning or error

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ If the service response contains no Cache-Control header, or if it contains no `
 By default, unsuccessful fetch responses are logged as errors by the `fetchMixin` ( `'error'` event type and `'request error'` event ).
 This behavior can be changed on classes implementing `fetchMixin` by overriding `logTypeForFetchError` function.
 
-For example, for a hypotetical `RiseXyzComponent` that extends `FetchMixin`:
+For example, a hypotetical `RiseXyzComponent` that extends `FetchMixin` could implement this function like this:
 
 ```
 logTypeForFetchError(error) {

--- a/README.md
+++ b/README.md
@@ -225,6 +225,33 @@ This parameter is disabled by default. When enabled, it will calculate a refresh
 
 If the service response contains no Cache-Control header, or if it contains no `max-age` value, the default `refresh` value will be used.
 
+### Log unsuccessful responses as either warning or error
+
+By default, unsuccessful fetch responses are logged as errors by the `fetchMixin` ( `'error'` event type and `'request error'` event ).
+This behavior can be changed on classes implementing `fetchMixin` by overriding `logTypeForFetchError` function.
+
+For example, for a hypotetical `RiseXyzComponent` that extends `FetchMixin`:
+
+```
+logTypeForFetchError(error) {
+  if (!error || !error.status) {
+    return RiseXyzComponent.LOG_TYPE_ERROR;
+  }
+
+  if (error.status === 403 || error.status === 429) {
+    return RiseXyzComponent.LOG_TYPE_WARNING;
+  }
+
+  if (error.status === 404 && error.responseText && error.responseText.startsWith("Username not found:")) {
+    return RiseXyzComponent.LOG_TYPE_WARNING;
+  }
+
+  return RiseXyzComponent.LOG_TYPE_ERROR;
+}
+```
+
+In this case, some status types will result instead in a `'warning'` event type and a `'request warning'` event.
+
 #### Fetch Example
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -146,6 +146,23 @@ export const FetchMixin = dedupingMixin( base => {
       }
     }
 
+    logTypeForFetchError() {
+      return Fetch.LOG_TYPE_ERROR;
+    }
+
+    _logFetchError( err ) {
+      const details = this._eventDetailFor( err );
+
+      if ( err && err.isOffline ) {
+        super.log( Fetch.LOG_TYPE_WARNING, "client offline", details );
+      } else {
+        const eventType = this.logTypeForFetchError( err );
+        const event = `request ${ eventType }`;
+
+        super.log( eventType, event, details );
+      }
+    }
+
     _handleFetchError( err ) {
       if ( this._shouldRetryFor( err )) {
         this._requestRetryCount += 1;
@@ -154,11 +171,7 @@ export const FetchMixin = dedupingMixin( base => {
       } else {
         this._requestRetryCount = 0;
 
-        if ( err && err.isOffline ) {
-          super.log( Fetch.LOG_TYPE_WARNING, "client offline", this._eventDetailFor( err ));
-        } else {
-          super.log( Fetch.LOG_TYPE_ERROR, "request error", this._eventDetailFor( err ));
-        }
+        this._logFetchError( err );
 
         this.processError && this.processError( err );
 

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -78,6 +78,18 @@ export const FetchMixin = dedupingMixin( base => {
       });
     }
 
+    _handleRejectedFetch( resp ) {
+      const error = new Error( `Request rejected with status ${resp.status}: ${resp.statusText}` );
+
+      error.status = resp.status;
+
+      return resp.text().then( text => {
+        error.responseText = text;
+
+        throw error;
+      });
+    }
+
     _requestData( cachedResp ) {
       return fetch( this._url, this._headers ).then( resp => {
         if ( resp.ok ) {
@@ -87,10 +99,7 @@ export const FetchMixin = dedupingMixin( base => {
 
           super.putCache && super.putCache( resp );
         } else {
-          const error = new Error( `Request rejected with status ${resp.status}: ${resp.statusText}` );
-
-          error.status = resp.status;
-          throw error;
+          return this._handleRejectedFetch( resp );
         }
       }).catch( err => {
         return super.isOffline().then( isOffline => {

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -186,6 +186,10 @@ export const FetchMixin = dedupingMixin( base => {
         detail.status = error.status;
       }
 
+      if ( error && error.responseText ) {
+        detail.responseText = error.responseText;
+      }
+
       return detail;
     }
 

--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,7 @@
     "unit/cache-mixin.html",
     "unit/cache-mixin-fallback.html",
     "unit/fetch-mixin.html",
+    "unit/fetch-mixin-error-type-override.html",
     "unit/valid-files-mixin.html",
     "unit/watch-files-mixin.html"
   ] );

--- a/test/unit/fetch-mixin-error-type-override.html
+++ b/test/unit/fetch-mixin-error-type-override.html
@@ -56,7 +56,7 @@
     suite("overriding behavior", () => {
       class ExampleElement extends Fetch {
         logTypeForFetchError(error) {
-          return error.code === 500 ? "error" : "warning"
+          return error.status === 500 ? "error" : "warning"
         }
       }
 
@@ -69,7 +69,7 @@
       });
 
       test( "should return error log type", () => {
-        element._logFetchError({ code: 500 });
+        element._logFetchError({ status: 500 });
 
         assert.isTrue(loggerMixin.log.calledOnce);
         assert.equal(loggerMixin.log.lastCall.args[0], "error");
@@ -77,7 +77,7 @@
       });
 
       test( "should return warning log type", () => {
-        element._logFetchError({ code: 400 });
+        element._logFetchError({ status: 400 });
 
         assert.isTrue(loggerMixin.log.calledOnce);
         assert.equal(loggerMixin.log.lastCall.args[0], "warning");

--- a/test/unit/fetch-mixin-error-type-override.html
+++ b/test/unit/fetch-mixin-error-type-override.html
@@ -1,0 +1,92 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script src="../../node_modules/chai/chai.js"></script>
+  <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+
+</head>
+
+<body>
+
+<script type="module">
+  import * as fetchModule from '../../src/fetch-mixin.js';
+
+  const DEFAULT_COOLDOWN = 1000 * 60 * 10;
+  const DEFAULT_REFRESH = 1000 * 60 * 60;
+  const DEFAULT_RETRY = 1000 * 60;
+
+  suite("fetch / error type override", () => {
+    const Fetch = fetchModule.FetchMixin(class {});
+
+    let element, loggerMixin;
+
+    teardown(()=>{
+      sinon.restore();
+    });
+
+    suite("default behavior", () => {
+      class ExampleElement extends Fetch {
+      }
+
+      setup(() => {
+        element = new ExampleElement();
+
+        loggerMixin = element.__proto__.__proto__.__proto__;
+
+        sinon.stub(loggerMixin, "log");
+      });
+
+      test( "should return default log type for any error", () => {
+        element._logFetchError();
+
+        assert.isTrue(loggerMixin.log.calledOnce);
+        assert.equal(loggerMixin.log.lastCall.args[0], "error");
+        assert.equal(loggerMixin.log.lastCall.args[1], "request error");
+      });
+    });
+
+    suite("overriding behavior", () => {
+      class ExampleElement extends Fetch {
+        logTypeForFetchError(error) {
+          return error.code === 500 ? "error" : "warning"
+        }
+      }
+
+      setup(() => {
+        element = new ExampleElement();
+
+        loggerMixin = element.__proto__.__proto__.__proto__;
+
+        sinon.stub(loggerMixin, "log");
+      });
+
+      test( "should return error log type", () => {
+        element._logFetchError({ code: 500 });
+
+        assert.isTrue(loggerMixin.log.calledOnce);
+        assert.equal(loggerMixin.log.lastCall.args[0], "error");
+        assert.equal(loggerMixin.log.lastCall.args[1], "request error");
+      });
+
+      test( "should return warning log type", () => {
+        element._logFetchError({ code: 400 });
+
+        assert.isTrue(loggerMixin.log.calledOnce);
+        assert.equal(loggerMixin.log.lastCall.args[0], "warning");
+        assert.equal(loggerMixin.log.lastCall.args[1], "request warning");
+      });
+    });
+
+  });
+</script>
+
+</body>
+</html>

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -615,6 +615,15 @@
 
         assert.deepEqual( detail, { error: "FAIL", status: 403 } );
       });
+
+      test( "should get event detail for event with message and response text", () => {
+        const detail = fetchMixin._eventDetailFor({
+          message: "FAIL",
+          responseText: "username not found"
+        });
+
+        assert.deepEqual( detail, { error: "FAIL", responseText: "username not found" } );
+      });
     });
 
   });

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -287,6 +287,7 @@
           const error = fetchMixin._handleFetchError.lastCall.args[0];
           assert( error );
           assert.equal( error.status, 500 );
+          assert.equal( error.responseText, validXmlData );
 
           done();
         });


### PR DESCRIPTION
## Description
Allow implementors of fetch-mixin to decide between logging warning or error depending on fetch failure status code and text.

Related PR: https://github.com/Rise-Vision/rise-data-twitter/pull/15

## Motivation and Context
Required by get-tweets service design, as not all fetch rejections should be treated as errors.

Also, the response text for errors is included in the error object used to determine if it's an error or a warning.

## How Has This Been Tested?
This branch was implemented by rise-data-twitter in [this branch](https://github.com/Rise-Vision/rise-data-twitter/compare/e2e/log-as-warning-or-error-depending-on-error-response?expand=1), and a username not found error was forced by a template using that component.

After running for a while, errors were detected for that display id:

```
SELECT ts, event, event_details
FROM client-side-events.Display_Events.events_test
WHERE ts >= "2020-03-18 00:00:00"
AND ts < "2020-03-19 00:00:00"
AND display_id = 'Z8RSGWXE8KR8'
ORDER BY ts DESC
```

and in this output we can validate that a 'warning' was sent instead of an error ( row 6 ) :  

https://docs.google.com/spreadsheets/d/15KT2KSOTyO8fY23Rh-Xm9qfWqjj3PjHoZzcJC8DPRYA/edit#gid=193684600

Also, tests for the overriding approach were created.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
    - This is a library, so it's not released directly into production.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support.
