### PR TITLE
Add override functions for customizing request url key for cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -153,15 +153,21 @@ export const CacheMixin = dedupingMixin( base => {
     }
 
     getCacheRequestKey( url ) {
-      // the intention of this function is it can be overridden by component to customize the key to save/get in cache
+      // the intention of this function is it can be overridden by component to customize the key to get in cache
       // main purpose of using this is when you want to pair a response with a custom string instead of request url
       return url;
+    }
+
+    putCacheRequestKey( response ) {
+      // the intention of this function is it can be overridden by component to customize the key to put in cache
+      // main purpose of using this is when you want to pair a response with a custom string instead of request url
+      return response.url;
     }
 
     putCache( response, url ) {
       if ( this._caches ) {
         return this._getCache().then( cache => {
-          return cache.put( response.url || this.getCacheRequestKey( url ), response );
+          return cache.put( this.putCacheRequestKey( response ) || url, response );
         }).catch( err => {
           super.log( Cache.LOG_TYPE_WARNING, "cache put failed", { url: response.url || url, err }, Cache.LOG_AT_MOST_ONCE_PER_DAY );
         });

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -152,10 +152,16 @@ export const CacheMixin = dedupingMixin( base => {
       }
     }
 
+    getCacheRequestKey( url ) {
+      // the intention of this function is it can be overridden by component to customize the key to save/get in cache
+      // main purpose of using this is when you want to pair a response with a custom string instead of request url
+      return url;
+    }
+
     putCache( response, url ) {
       if ( this._caches ) {
         return this._getCache().then( cache => {
-          return cache.put( response.url || url, response );
+          return cache.put( response.url || this.getCacheRequestKey( url ), response );
         }).catch( err => {
           super.log( Cache.LOG_TYPE_WARNING, "cache put failed", { url: response.url || url, err }, Cache.LOG_AT_MOST_ONCE_PER_DAY );
         });
@@ -170,7 +176,7 @@ export const CacheMixin = dedupingMixin( base => {
 
         return this._getCache().then( cache => {
           _cache = cache;
-          return cache.match( url );
+          return cache.match( this.getCacheRequestKey( url ));
         }).then( response => {
           if ( !this._isResponseExpired( response, this.cacheConfig.refresh )) {
             return Promise.resolve( response );

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -152,16 +152,17 @@ export const CacheMixin = dedupingMixin( base => {
       }
     }
 
+    /*
+     The intention of getCacheRequestKey and putCacheRequestKey functions below is they can be overridden by a component to customize
+     the key to put/get in cache. The main purpose of using this is when you want to pair a response with a custom string
+     instead of request url
+     */
     getCacheRequestKey( url ) {
-      // the intention of this function is it can be overridden by component to customize the key to get in cache
-      // main purpose of using this is when you want to pair a response with a custom string instead of request url
       return url;
     }
 
     putCacheRequestKey( response ) {
-      // the intention of this function is it can be overridden by component to customize the key to put in cache
-      // main purpose of using this is when you want to pair a response with a custom string instead of request url
-      return response.url;
+      return response.url || null;
     }
 
     putCache( response, url ) {

--- a/src/cache-mixin.js
+++ b/src/cache-mixin.js
@@ -153,22 +153,22 @@ export const CacheMixin = dedupingMixin( base => {
     }
 
     /*
-     The intention of getCacheRequestKey and putCacheRequestKey functions below is they can be overridden by a component to customize
-     the key to put/get in cache. The main purpose of using this is when you want to pair a response with a custom string
+     The intention of getCacheRequestKey and getCacheResponseKey functions below is they can be overridden by a component to customize
+     the key for a cache entry. The main purpose of using this is when you want to pair a response with a custom string
      instead of request url
      */
     getCacheRequestKey( url ) {
       return url;
     }
 
-    putCacheRequestKey( response ) {
+    getCacheResponseKey( response ) {
       return response.url || null;
     }
 
     putCache( response, url ) {
       if ( this._caches ) {
         return this._getCache().then( cache => {
-          return cache.put( this.putCacheRequestKey( response ) || url, response );
+          return cache.put( this.getCacheResponseKey( response ) || url, response );
         }).catch( err => {
           super.log( Cache.LOG_TYPE_WARNING, "cache put failed", { url: response.url || url, err }, Cache.LOG_AT_MOST_ONCE_PER_DAY );
         });


### PR DESCRIPTION
## Description
Adding `getCacheRequestKey` and `putCacheRequestKey` functions that continue to execute current functionality of cache-mixin. 

The intention of these functions is they can be overridden by a component to customize the key to put/get in cache. The main purpose of using this is when you want to pair a response with a custom string instead of request url

Corresponding usage in PR https://github.com/Rise-Vision/rise-data-twitter/pull/35

## Motivation and Context
Twitter component requires a custom cache key because every request to Twitter service that it makes consists of query params that can and will have different values per each request. This defeats the purpose of using Cache API and will pollute the cache with unused entries. 

The ability to customize the cache request key to pair with the response solves this problem.

## How Has This Been Tested?
Tested in apps staging via Charles mapping to local version of twitter component targeting this branch of rise-common-component. 

https://www.screencast.com/t/jsQKAXVGKHyZ

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
