### PR TITLE
Handle "rise-presentation-play" and "rise-presentation-stop” events

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ class RiseDataWeather extends RiseElement {}
 `RiseElement` provides a few utility functions:
 - `ready()` is called by the Component once initialized.
 - `_init()` is called once RisePlayerConfiguration has been initialized.
-- `_handleStart()` is called once the Component is required to start playing.
+- `_handleStart()` is called once the Component is required to start playing. Use it for components with static content like text.
+- `_handleRisePresentationPlay()` is similar to `_handleStart`, but is called every time the component needs to start playing content. Use it for the components with dynamic content like playlist or video.
+- `_handleRisePresentationStop()` is called when component needs to stop playing content. Use it in conjunction with `_handleRisePresentationPlay()`.
 
 You don't have to extend these functions, but if you do, don't forget to call the `super.***()` function to ensure everything works as expected.
 
@@ -60,6 +62,18 @@ class RiseExample extends RiseElement {
 
   _handleStart() {
     super._handleStart();
+
+    // your code here
+  }
+
+  _handleRisePresentationPlay() {
+    super._handleRisePresentationPlay();
+
+    // your code here
+  }
+
+  _handleRisePresentationStop() {
+    super._handleRisePresentationStop();
 
     // your code here
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.5.1",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1244,15 +1244,15 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
       "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
       "requires": {
-        "acorn": "7.1.1",
+        "acorn": "7.2.0",
         "acorn-jsx": "5.2.0",
         "eslint-visitor-keys": "1.1.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
         }
       }
     },
@@ -1344,14 +1344,6 @@
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "requires": {
         "flat-cache": "2.0.1"
-      }
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "requires": {
-        "to-regex-range": "5.0.1"
       }
     },
     "find-up": {
@@ -1796,11 +1788,6 @@
       "requires": {
         "is-extglob": "2.1.1"
       }
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -3241,18 +3228,7 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
           "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
           "requires": {
-            "braces": "3.0.2",
             "picomatch": "2.2.1"
-          },
-          "dependencies": {
-            "braces": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-              "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-              "requires": {
-                "fill-range": "7.0.1"
-              }
-            }
           }
         },
         "require-main-filename": {
@@ -3366,14 +3342,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
-      }
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "requires": {
-        "is-number": "7.0.0"
       }
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/rise-element.js
+++ b/src/rise-element.js
@@ -43,6 +43,12 @@ export const RiseElementMixin = dedupingMixin( base => {
       static get EVENT_CLIENT_OFFLINE() {
         return "client-offline"
       }
+      static get EVENT_RISE_PRESENTATION_PLAY() {
+        return "rise-presentation-play"
+      }
+      static get EVENT_RISE_PRESENTATION_STOP() {
+        return "rise-presentation-stop"
+      }
 
       // General constants
       static get STORAGE_PREFIX() {
@@ -97,6 +103,8 @@ export const RiseElementMixin = dedupingMixin( base => {
 
       _init() {
         this.addEventListener( RiseElement.EVENT_START, this._handleStart, { once: true });
+        this.addEventListener( RiseElement.EVENT_RISE_PRESENTATION_PLAY, this._handleRisePresentationPlay );
+        this.addEventListener( RiseElement.EVENT_RISE_PRESENTATION_STOP, this._handleRisePresentationStop );
 
         this._sendEvent( RiseElement.EVENT_CONFIGURED );
       }
@@ -113,7 +121,14 @@ export const RiseElementMixin = dedupingMixin( base => {
         super.log( riseElement.LOG_TYPE_INFO, "start received" );
       }
 
+      _handleRisePresentationPlay() {
+      }
+
+      _handleRisePresentationStop() {
+      }
+
       _handleUptimeRequest() {
+
         window.dispatchEvent( new CustomEvent( "component-uptime-result", {
           detail: {
             component_id: this.id,

--- a/test/unit/rise-element.html
+++ b/test/unit/rise-element.html
@@ -44,6 +44,7 @@
     });
 
     teardown(()=>{
+      RisePlayerConfiguration.isConfigured = () => false;
       sinon.restore();
     });
 
@@ -140,11 +141,31 @@
       });
     });
 
-    suite( "'start' event", () => {
-      test( "should start", () => {
-        element.dispatchEvent( new CustomEvent( "start" ) );
+    suite( "'start/play/stop' event", () => {
 
+      test( "should start", () => {
+        sinon.spy(element, "_handleStart");
+        element._init();
+        element.dispatchEvent( new CustomEvent( "start" ));
+
+        assert.isTrue( element._handleStart.calledOnce );
         assert.deepEqual( logger.log.getCall(0).args, ["info", "start received"] );
+      });
+
+      test( "should call _handleRisePresentationPlay", () => {
+        sinon.stub(element, "_handleRisePresentationPlay");
+        element._init();
+        element.dispatchEvent( new CustomEvent( "rise-presentation-play" ) );
+
+        assert.isTrue( element._handleRisePresentationPlay.calledOnce );
+      });
+
+      test( "should call _handleRisePresentationStop", () => {
+        sinon.stub(element, "_handleRisePresentationStop");
+        element._init();
+        element.dispatchEvent( new CustomEvent( "rise-presentation-stop" ) );
+
+        assert.isTrue( element._handleRisePresentationStop.calledOnce );
       });
     });
 


### PR DESCRIPTION
## Description
This is part 1 of 2. Part 2 is [here](https://github.com/Rise-Vision/rise-playlist-new/pull/30).
Move `"rise-presentation-play"` and `"rise-presentation-stop”` event handlers from `rise-playlist-new` to `rise-common-component`. Those events are not specific to the `rise-playlist-new` only and don't belong there.

## Motivation and Context
Motivated by issue https://github.com/Rise-Vision/rise-embedded-template/issues/17. The is an alternative fix for the issue. Registering event handlers before sending `"configured"` to the `common-template` [here](https://github.com/Rise-Vision/rise-common-component/compare/stage/add-play-event-handler?expand=1#diff-984deaa28b4ffc2771d3d888d97b7223R109) guarantees that `"rise-presentation-play"` event won't be missed in case if `common-template` handles `"configured"` synchronously (which was the case before https://github.com/Rise-Vision/common-template/pull/119).

## How Has This Been Tested?
New unit tests are added.
Tested manually on local machine using template with `rise-playlist` component and Charles proxy. Confirmed that `rise-playlist` component receives `"rise-presentation-play"`.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
