### PR TITLE
Add class to StoreFilesMixin for storing last requested data in LocalStorage

### DIFF
--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -3,9 +3,64 @@ import { CacheMixin } from "./cache-mixin.js";
 
 export const StoreFilesMixin = dedupingMixin( base => {
   const CACHE_CONFIG = {
-    name: "store-files-mixin",
-    refresh: 1000 * 60 * 60 * 2,
-    expiry: 1000 * 60 * 60 * 4
+      name: "store-files-mixin",
+      refresh: 1000 * 60 * 60 * 2,
+      expiry: 1000 * 60 * 60 * 4
+    },
+    LOCAL_STORAGE_KEY = "rise_files_last_requested";
+
+  class LastRequestedStorage {
+    constructor() {
+      this._isSupported = this._isLocalStorageSupported();
+    }
+
+    save( fileUrl, timestamp ) {
+      if ( !this._isSupported ) {
+        return;
+      }
+
+      if ( !fileUrl || !timestamp || typeof timestamp !== "number" ) {
+        return;
+      }
+
+      const map = this._getMap();
+
+      map.set( fileUrl, timestamp );
+
+      this._saveMap( map );
+    }
+
+    _isLocalStorageSupported() {
+      const test = "test";
+
+      try {
+        localStorage.setItem( test, test );
+        localStorage.removeItem( test );
+        return true;
+      } catch ( e ) {
+        return false;
+      }
+    }
+
+    _getMap() {
+      let map;
+
+      try {
+        map = new Map( JSON.parse( localStorage.getItem( LOCAL_STORAGE_KEY )));
+      } catch ( e ) {
+        console.warn( e ); // eslint-disable-line no-console
+        map = new Map();
+      }
+      return map;
+    }
+
+    _saveMap( map ) {
+      if ( !map || !( map instanceof Map )) {
+        return;
+      }
+
+      localStorage.setItem( LOCAL_STORAGE_KEY, JSON.stringify( Array.from( map )));
+    }
   }
 
   class StoreFiles extends CacheMixin( base ) {
@@ -13,6 +68,7 @@ export const StoreFilesMixin = dedupingMixin( base => {
       super();
 
       this.cacheConfig = Object.assign({}, CACHE_CONFIG );
+      this.lastRequestedStorage = new LastRequestedStorage();
     }
 
     getFile( fileUrl ) {

--- a/test/index.html
+++ b/test/index.html
@@ -21,7 +21,8 @@
     "unit/fetch-mixin-error-type-override.html",
     "unit/valid-files-mixin.html",
     "unit/watch-files-mixin.html",
-    "unit/store-files-mixin.html"
+    "unit/store-files-mixin.html",
+    "unit/store-files-mixin-last-requested.html"
   ] );
 </script>
 </body>

--- a/test/unit/store-files-mixin-last-requested.html
+++ b/test/unit/store-files-mixin-last-requested.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script src="../../node_modules/chai/chai.js"></script>
+  <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+</head>
+<body>
+<script type="text/javascript">
+  function createLocalStorageStub() {
+    const map = new Map([
+      ["https://storage.googleapis.com/risemedialibrary-abc123/test1.jpg", 1591811669657],
+      ["https://storage.googleapis.com/risemedialibrary-abc123/test2.jpg", 1591811724512]
+    ]);
+
+    localStorage.setItem("rise_files_last_requested", JSON.stringify(Array.from(map)));
+
+    sinon.spy(localStorage, "getItem");
+    sinon.spy(localStorage, "setItem");
+  }
+
+  function removeLocalStorageStub() {
+    localStorage.removeItem("rise_files_last_requested");
+
+    localStorage.getItem.restore();
+    localStorage.setItem.restore();
+  }
+</script>
+<script type="module">
+  import * as storeFilesModule from '../../src/store-files-mixin.js'
+
+  suite("last requested storage", () => {
+    let lastRequestedStorage;
+
+    setup(() => {
+      const StoreFiles = storeFilesModule.StoreFilesMixin(class {});
+      lastRequestedStorage = new StoreFiles().lastRequestedStorage;
+
+      createLocalStorageStub();
+    });
+
+    teardown(() => {
+      sinon.restore();
+    });
+
+    suite("_getMap", () => {
+      test("should return map of last requested data from Local Storage", () => {
+        const map = lastRequestedStorage._getMap();
+
+        assert.deepEqual(Array.from(map), [
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test1.jpg", 1591811669657],
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test2.jpg", 1591811724512]
+        ]);
+      });
+
+      test("should return empty map if no data available", () => {
+        removeLocalStorageStub();
+
+        const map = lastRequestedStorage._getMap();
+
+        assert.deepEqual(Array.from(map), []);
+      });
+    });
+
+    suite("_saveMap", () => {
+      test("should not save if map provided is invalid", () => {
+        lastRequestedStorage._saveMap();
+        assert.isFalse(localStorage.setItem.called);
+
+        lastRequestedStorage._saveMap("test");
+        assert.isFalse(localStorage.setItem.called);
+
+        lastRequestedStorage._saveMap(123);
+        assert.isFalse(localStorage.setItem.called);
+
+        lastRequestedStorage._saveMap(["test"]);
+        assert.isFalse(localStorage.setItem.called);
+
+        lastRequestedStorage._saveMap(new Map());
+        assert.isTrue(localStorage.setItem.called);
+      });
+
+      test("should call setItem() of localStorage with correct key and the provided map stringified", () => {
+        const map = new Map([
+          ["test1", 123],
+          ["test2", 456]
+        ]);
+
+        lastRequestedStorage._saveMap(map);
+
+        assert.isTrue(localStorage.setItem.calledWith("rise_files_last_requested", JSON.stringify(Array.from(map))));
+      });
+    });
+
+    suite("save", () => {
+      test("should not execute if local storage not supported", () => {
+        lastRequestedStorage._isSupported = false;
+        sinon.stub(lastRequestedStorage,"_getMap");
+
+        lastRequestedStorage.save("test", 123);
+
+        assert.isFalse(lastRequestedStorage._getMap.called);
+      });
+
+      test("should not execute if params are invalid", () => {
+        sinon.stub(lastRequestedStorage,"_getMap");
+
+        lastRequestedStorage.save();
+        assert.isFalse(lastRequestedStorage._getMap.called);
+
+        lastRequestedStorage.save("test");
+        assert.isFalse(lastRequestedStorage._getMap.called);
+
+        lastRequestedStorage.save("test", "test");
+        assert.isFalse(lastRequestedStorage._getMap.called);
+      });
+
+      test("should save new item of last requested data to Local Storage", () => {
+        lastRequestedStorage.save("https://storage.googleapis.com/risemedialibrary-abc123/test3.jpg", 1591816247812);
+
+        assert.deepEqual(Array.from(lastRequestedStorage._getMap()), [
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test1.jpg", 1591811669657],
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test2.jpg", 1591811724512],
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test3.jpg", 1591816247812]
+        ]);
+      });
+
+      test("should save an updated item of last requested data to Local Storage", () => {
+        lastRequestedStorage.save("https://storage.googleapis.com/risemedialibrary-abc123/test2.jpg", 1591816421014);
+
+        assert.deepEqual(Array.from(lastRequestedStorage._getMap()), [
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test1.jpg", 1591811669657],
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test2.jpg", 1591816421014]
+        ]);
+      });
+    })
+
+  });
+
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Description
Added `LastRequestedStorage` class to StoreFilesMixin. This class provides StoreFilesMixin ability to save _last requested_ timestamp for a file request in browser LocalStorage. 

An instance of LastRequestedStorage is instantiated in the constructor of StoreFilesMixin. 

LastRequestedStorage provides one main function `save` which accepts 2 parameters:

- _fileUrl_: the request url for a file
- _timestamp_: a timestamp (Number) value that represents the last time the request for that url was made.

The rest of functionality executes the requirements as per the [technical design](https://docs.google.com/document/d/1P1s4hasqmN_f5ZL2Q4uzjY8C-Ic-FE4sEPfiv96bNKo/edit#bookmark=id.5kt6yhk9adpt) for storing timestamp per request url in LocalStorage. 

## Motivation and Context
Small incremental steps to caching images and video in Browser. Specifically, this is a piece of the mechanism for purging old files from Cache - see [technical design](https://docs.google.com/document/d/1P1s4hasqmN_f5ZL2Q4uzjY8C-Ic-FE4sEPfiv96bNKo/edit#bookmark=id.1bm1rn350aa2) for more detail.

## How Has This Been Tested?
Added unit tests which uses actual browser LocalStorage. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
