### PR TITLE
Chore/handle cached response

### DIFF
--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -16,36 +16,85 @@ export const StoreFilesMixin = dedupingMixin( base => {
     }
 
     getFile( fileUrl ) {
-      return super.getCache( fileUrl ).then(() => {
-        return this._handleCachedFile();
+      return super.getCache( fileUrl ).then( cache => {
+        console.log('CACHED');
+        return this._handleCachedFile( fileUrl, cache );
       }).catch(() => {
+        console.log('REQUESTED');        
         return this._requestFile( fileUrl );
       })
     }
 
-    _handleCachedFile() {
-      // TODO: Check file version and update it if needed and return it.
+    _handleCachedFile( fileUrl, cache ) {
+      console.log( "cache", cache );
+      let dateSinceModified = 1561661041,
+        respToCache;
+
+      // return fetch( fileUrl )
+      return fetch( fileUrl, {
+          headers: {
+            "If-Modified-Since": dateSinceModified
+          },
+          mode: "cors" 
+        } )
+        .then( resp => {
+          if ( resp.status === 200 ) {
+            respToCache = resp.clone();
+            super.putCache( respToCache );
+            return this._getFileRepresentation( resp );
+          } else if ( resp.status === 304 ) {
+            return this._getFileRepresentation( cache );
+          }
+        })
+        .catch( err => {
+          console.error( "", err );
+        })
+      // TODO: send if-match-since request
+      // TODO:   check response.status
+      // TODO:     handle 200 status code
+      // TODO:       putCache
+      // TODO:       _getFileRepresentation
+      // TODO:     handle 300 status code
+      // TODO:       _getFileRepresentation
     }
 
     _requestFile( fileUrl ) {
-      let response;
+      let respToCache;
 
       return fetch( fileUrl )
         .then( resp => {
-          response = resp.clone();
-          return resp.blob();
-        })
-        .then( blob => {
-          return URL.createObjectURL( blob );
+          respToCache = resp.clone();
+          return this._getFileRepresentation( resp );
         })
         .then( objectURL => {
-          super.putCache( response );
+          super.putCache( respToCache );
           return objectURL;
         })
         .catch(() => {
           // TODO: handle errors
         })
     }
+
+    _getFileRepresentation( resp ) {
+      return resp.blob().then( blob => {
+        return URL.createObjectURL( blob );
+      })
+    }
+
+    _getCacheCustom() {
+      if ( this._caches ) {
+        let _cache;
+
+        return this._getCache().then( cache => {
+          _cache = cache;
+          return cache.match( this.getCacheRequestKey( url ));
+        })
+      } else {
+        return Promise.reject();
+      }
+    }
+
+  }
 
   }
 

--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -67,36 +67,32 @@ export const StoreFilesMixin = dedupingMixin( base => {
     constructor() {
       super();
 
-      this.cacheConfig = Object.assign({}, CACHE_CONFIG );
       this.lastRequestedStorage = new LastRequestedStorage();
+      this.cacheConfig = Object.assign({}, CACHE_CONFIG );
     }
 
     getFile( fileUrl ) {
-      return super.getCache( fileUrl ).then( cache => {
-        console.log('CACHED');
+      return this._getCacheCustom( fileUrl ).then( cache => {
         return this._handleCachedFile( fileUrl, cache );
       }).catch(() => {
-        console.log('REQUESTED');        
         return this._requestFile( fileUrl );
       })
     }
 
     _handleCachedFile( fileUrl, cache ) {
-      console.log( "cache", cache );
-      let dateSinceModified = 1561661041,
-        respToCache;
+      let respToCache;
 
-      // return fetch( fileUrl )
-      return fetch( fileUrl, {
-          headers: {
-            "If-Modified-Since": dateSinceModified
-          },
-          mode: "cors" 
-        } )
+      return fetch( fileUrl )
+      // return fetch( fileUrl, {
+      //     headers: {
+      //       "If-Modified-Since": dateSinceModified
+      //     }
+      //   } )
         .then( resp => {
           if ( resp.status === 200 ) {
             respToCache = resp.clone();
             super.putCache( respToCache );
+            this.lastRequestedStorage.save( fileUrl, Date.now());
             return this._getFileRepresentation( resp );
           } else if ( resp.status === 304 ) {
             return this._getFileRepresentation( cache );
@@ -105,13 +101,6 @@ export const StoreFilesMixin = dedupingMixin( base => {
         .catch( err => {
           console.error( "", err );
         })
-      // TODO: send if-match-since request
-      // TODO:   check response.status
-      // TODO:     handle 200 status code
-      // TODO:       putCache
-      // TODO:       _getFileRepresentation
-      // TODO:     handle 300 status code
-      // TODO:       _getFileRepresentation
     }
 
     _requestFile( fileUrl ) {
@@ -123,7 +112,7 @@ export const StoreFilesMixin = dedupingMixin( base => {
           return this._getFileRepresentation( resp );
         })
         .then( objectURL => {
-          super.putCache( respToCache );
+          super.putCache( respToCache, fileUrl );
           return objectURL;
         })
         .catch(() => {
@@ -137,20 +126,13 @@ export const StoreFilesMixin = dedupingMixin( base => {
       })
     }
 
-    _getCacheCustom() {
-      if ( this._caches ) {
-        let _cache;
-
-        return this._getCache().then( cache => {
-          _cache = cache;
-          return cache.match( this.getCacheRequestKey( url ));
-        })
-      } else {
-        return Promise.reject();
-      }
+    _getCacheCustom( url ) {
+      return super._getCache().then( cache => {
+        return cache.match( this.getCacheRequestKey( url ));
+      }).then( response => {
+        return Promise.resolve( response );
+      })
     }
-
-  }
 
   }
 

--- a/test/unit/store-files-mixin.html
+++ b/test/unit/store-files-mixin.html
@@ -36,7 +36,7 @@
         suite( "get", () => {
           test( "should call cache handler if cache is available and valid", done => {
             sinon.stub(storeFilesMixin.__proto__, "_handleCachedFile");
-            let stubbedCache = sinon.stub(storeFilesMixin.__proto__.__proto__, "getCache");
+            let stubbedCache = sinon.stub(storeFilesMixin, "_getCache");
             stubbedCache.resolves(Promise.resolve());
 
             storeFilesMixin.getFile().then(() => {

--- a/test/unit/store-files-mixin.html
+++ b/test/unit/store-files-mixin.html
@@ -86,20 +86,11 @@
             });
           });
 
-          test( "should creat objectUrl ", done => {
-            window.fetch.resolves(response);
-
-            storeFilesMixin._requestFile().then(() => {
-              assert.isTrue( URL.createObjectURL.called );
-              done();
-            });
-          });
-
-
           test( "should cache response and creat objectUrl ", done => {
             window.fetch.resolves(response);
 
             storeFilesMixin._requestFile().then(() => {
+              assert.isTrue( URL.createObjectURL.called );
               assert.isTrue( cacheMixin.putCache.called );
               done();
             });

--- a/test/unit/store-files-mixin.html
+++ b/test/unit/store-files-mixin.html
@@ -75,7 +75,7 @@
               done();
             })
           });
-  
+
           test( "should extract blob", done => {
             window.fetch.resolves(response);
             response.blob = sinon.stub();
@@ -95,6 +95,84 @@
               assert.isTrue( URL.createObjectURL.called );
               done();
             });
+          });
+        });
+
+        suite( "_handleCachedFile", () => {
+          const validXmlData = "<report><observation temperature=\"12\"/><location/></report>";
+          let response;
+
+          setup(() => {
+            response = new Response(validXmlData,{headers:{date: new Date()}});
+            cacheMixin.putCache = sinon.stub().resolves();
+            URL.createObjectURL = sinon.stub();
+          });
+
+          suite( "response 200", () => {
+            test( "should update cached file", done => {
+              response.blob = sinon.stub().resolves();
+              window.fetch.resolves(response);
+
+              storeFilesMixin._handleCachedFile("file url").then(() => {
+                assert.isTrue( cacheMixin.putCache.called );
+                done();
+              });
+            });
+
+            test( "should return file representation", done => {
+              window.fetch.resolves(response);
+
+              storeFilesMixin._handleCachedFile("file url").then((res) => {
+                assert.isTrue( URL.createObjectURL.called );
+                done();
+              });
+            });
+          });
+
+          suite( "response 304", () => {
+            let cachedResponse;
+
+            setup(() => {
+              cachedResponse = new Response(validXmlData, {
+                headers: {date: new Date()}
+              });
+
+              response = new Response(null, {
+                status: 304,
+                headers: {date: new Date()}
+              });
+            });
+
+            test( "should return cached file representation", done => {
+              response.blob = sinon.stub().resolves();
+              storeFilesMixin._getFileRepresentation = sinon.stub().resolves();
+              window.fetch.resolves(response);
+
+              storeFilesMixin._handleCachedFile("file url", cachedResponse).then((res) => {
+                assert.isTrue( storeFilesMixin._getFileRepresentation.calledWith( cachedResponse ) );
+                done();
+              });
+            });
+          });
+        });
+
+        suite( "_getFileRepresentation", () => {
+          const validXmlData = "<report><observation temperature=\"12\"/><location/></report>";
+          let response;
+
+          setup(() => {
+            response = new Response(validXmlData,{headers:{date: new Date()}});
+            URL.createObjectURL = sinon.stub();
+          });
+
+          test( "should return file representation", done => {
+              response.blob = sinon.stub().resolves( "BLOB" );
+
+              storeFilesMixin._getFileRepresentation( response ).then(() => {
+                assert.isTrue( response.blob.called );
+                assert.isTrue( URL.createObjectURL.calledWith( "BLOB" ) );
+                done();
+              });
           });
         });
       });


### PR DESCRIPTION
## Description
StoreFilesMixin handles cached responses: Execute Fetch request for the file with If-modified-since header, handle 200 response, handle 304 response. + Unit tests

## Motivation and Context
When file is cached, this code checks version of cached file and updates it if needed.

## How Has This Been Tested?
Manually in apps with mapping to local file. +Unit tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
