### PR TITLE
Chore/handle cached response

### DIFF
--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -19,7 +19,7 @@ export const StoreFilesMixin = dedupingMixin( base => {
         return;
       }
 
-      if ( !fileUrl || !timestamp || typeof timestamp !== "number" ) {
+      if ( !fileUrl || !timestamp ) {
         return;
       }
 

--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -135,6 +135,11 @@ export const StoreFilesMixin = dedupingMixin( base => {
       return fetch( fileUrl )
         .then( resp => {
           respToCache = resp.clone();
+
+          let timestamp = new Date();
+
+          this.lastRequestedStorage.save( fileUrl, timestamp.toUTCString());
+
           return this._getFileRepresentation( resp );
         })
         .then( objectURL => {

--- a/test/unit/store-files-mixin-last-requested.html
+++ b/test/unit/store-files-mixin-last-requested.html
@@ -117,9 +117,6 @@
 
         lastRequestedStorage.save("test");
         assert.isFalse(lastRequestedStorage._getMap.called);
-
-        lastRequestedStorage.save("test", "test");
-        assert.isFalse(lastRequestedStorage._getMap.called);
       });
 
       test("should save new item of last requested data to Local Storage", () => {


### PR DESCRIPTION
## Description
It a small but crucial fix. Because of the wrong condition LastRequesteStorage fallback was not working properly and we need to set timestamp on first image request too.

## Motivation and Context
Bugfix

## How Has This Been Tested?
unit tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
