### PR TITLE
Add class to StoreFilesMixin for storing timestamp of last HEAD request in LocalStorage

### DIFF
--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -7,6 +7,7 @@ export const StoreFilesMixin = dedupingMixin( base => {
       refresh: 1000 * 60 * 60 * 2,
       expiry: 1000 * 60 * 60 * 4
     },
+    LOCAL_STORAGE_KEY = "rise_files_last_requested",
     deletedFileStatusCodes = [ 401, 403, 404 ],
     fileStatuses = {
       fresh: "fresh",
@@ -14,10 +15,76 @@ export const StoreFilesMixin = dedupingMixin( base => {
       deleted: "deleted"
     };
 
+  class LastRequestedStorage {
+    constructor() {
+      this._isSupported = this._isLocalStorageSupported();
+    }
+
+    save( fileUrl, timestamp ) {
+      if ( !this._isSupported ) {
+        return;
+      }
+
+      if ( !fileUrl || !timestamp ) {
+        return;
+      }
+
+      const map = this._getMap();
+
+      map.set( fileUrl, timestamp );
+
+      this._saveMap( map );
+    }
+
+    getTimestamp( fileUrl ) {
+      if ( !this._isSupported || !fileUrl ) {
+        return;
+      }
+
+      const map = this._getMap();
+
+      return map.get( fileUrl )
+    }
+
+    _isLocalStorageSupported() {
+      const test = "test";
+
+      try {
+        localStorage.setItem( test, test );
+        localStorage.removeItem( test );
+        return true;
+      } catch ( e ) {
+        return false;
+      }
+    }
+
+    _getMap() {
+      let map;
+
+      try {
+        map = new Map( JSON.parse( localStorage.getItem( LOCAL_STORAGE_KEY )));
+      } catch ( e ) {
+        console.warn( e ); // eslint-disable-line no-console
+        map = new Map();
+      }
+      return map;
+    }
+
+    _saveMap( map ) {
+      if ( !map || !( map instanceof Map )) {
+        return;
+      }
+
+      localStorage.setItem( LOCAL_STORAGE_KEY, JSON.stringify( Array.from( map )));
+    }
+  }
+
+
   class StoreFiles extends CacheMixin( base ) {
     constructor() {
       super();
 
+      this.lastRequestedStorage = new LastRequestedStorage();
       this.cacheConfig = Object.assign({}, CACHE_CONFIG );
     }
 

--- a/test/index.html
+++ b/test/index.html
@@ -22,6 +22,7 @@
     "unit/valid-files-mixin.html",
     "unit/watch-files-mixin.html",
     "unit/store-files-mixin.html",
+    "unit/store-files-mixin-last-requested.html",
   ] );
 </script>
 </body>

--- a/test/unit/store-files-mixin-last-requested.html
+++ b/test/unit/store-files-mixin-last-requested.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script src="../../node_modules/chai/chai.js"></script>
+  <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+</head>
+<body>
+<script type="text/javascript">
+  function createLocalStorageStub() {
+    const map = new Map([
+      ["https://storage.googleapis.com/risemedialibrary-abc123/test1.jpg", 1591811669657],
+      ["https://storage.googleapis.com/risemedialibrary-abc123/test2.jpg", 1591811724512]
+    ]);
+
+    localStorage.setItem("rise_files_last_requested", JSON.stringify(Array.from(map)));
+
+    sinon.spy(localStorage, "getItem");
+    sinon.spy(localStorage, "setItem");
+  }
+
+  function removeLocalStorageStub() {
+    localStorage.removeItem("rise_files_last_requested");
+
+    localStorage.getItem.restore();
+    localStorage.setItem.restore();
+  }
+</script>
+<script type="module">
+  import * as storeFilesModule from '../../src/store-files-mixin.js'
+
+  suite("last requested storage", () => {
+    let lastRequestedStorage;
+
+    setup(() => {
+      const StoreFiles = storeFilesModule.StoreFilesMixin(class {});
+      lastRequestedStorage = new StoreFiles().lastRequestedStorage;
+
+      createLocalStorageStub();
+    });
+
+    teardown(() => {
+      sinon.restore();
+    });
+
+    suite("_getMap", () => {
+      test("should return map of last requested data from Local Storage", () => {
+        const map = lastRequestedStorage._getMap();
+
+        assert.deepEqual(Array.from(map), [
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test1.jpg", 1591811669657],
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test2.jpg", 1591811724512]
+        ]);
+      });
+
+      test("should return empty map if no data available", () => {
+        removeLocalStorageStub();
+
+        const map = lastRequestedStorage._getMap();
+
+        assert.deepEqual(Array.from(map), []);
+      });
+    });
+
+    suite("_saveMap", () => {
+      test("should not save if map provided is invalid", () => {
+        lastRequestedStorage._saveMap();
+        assert.isFalse(localStorage.setItem.called);
+
+        lastRequestedStorage._saveMap("test");
+        assert.isFalse(localStorage.setItem.called);
+
+        lastRequestedStorage._saveMap(123);
+        assert.isFalse(localStorage.setItem.called);
+
+        lastRequestedStorage._saveMap(["test"]);
+        assert.isFalse(localStorage.setItem.called);
+
+        lastRequestedStorage._saveMap(new Map());
+        assert.isTrue(localStorage.setItem.called);
+      });
+
+      test("should call setItem() of localStorage with correct key and the provided map stringified", () => {
+        const map = new Map([
+          ["test1", 123],
+          ["test2", 456]
+        ]);
+
+        lastRequestedStorage._saveMap(map);
+
+        assert.isTrue(localStorage.setItem.calledWith("rise_files_last_requested", JSON.stringify(Array.from(map))));
+      });
+    });
+
+    suite("save", () => {
+      test("should not execute if local storage not supported", () => {
+        lastRequestedStorage._isSupported = false;
+        sinon.stub(lastRequestedStorage,"_getMap");
+
+        lastRequestedStorage.save("test", 123);
+
+        assert.isFalse(lastRequestedStorage._getMap.called);
+      });
+
+      test("should not execute if params are invalid", () => {
+        sinon.stub(lastRequestedStorage,"_getMap");
+
+        lastRequestedStorage.save();
+        assert.isFalse(lastRequestedStorage._getMap.called);
+
+        lastRequestedStorage.save("test");
+        assert.isFalse(lastRequestedStorage._getMap.called);
+      });
+
+      test("should save new item of last requested data to Local Storage", () => {
+        lastRequestedStorage.save("https://storage.googleapis.com/risemedialibrary-abc123/test3.jpg", 1591816247812);
+
+        assert.deepEqual(Array.from(lastRequestedStorage._getMap()), [
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test1.jpg", 1591811669657],
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test2.jpg", 1591811724512],
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test3.jpg", 1591816247812]
+        ]);
+      });
+
+      test("should save an updated item of last requested data to Local Storage", () => {
+        lastRequestedStorage.save("https://storage.googleapis.com/risemedialibrary-abc123/test2.jpg", 1591816421014);
+
+        assert.deepEqual(Array.from(lastRequestedStorage._getMap()), [
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test1.jpg", 1591811669657],
+          ["https://storage.googleapis.com/risemedialibrary-abc123/test2.jpg", 1591816421014]
+        ]);
+      });
+    })
+
+  });
+
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Description
Reinstating `LastRequestedStorage` class to StoreFilesMixin. This class provides StoreFilesMixin ability to save in browser LocalStorage the last time (timestamp) a HEAD request was made for a file . 

## Motivation and Context
This has been reinstated due Browser caching HEAD requests which is defeating the purpose of making one as we are wanting to do a `etag` comparison to know if the file has changed. 

The plan is to append a cachebuster (current timestamp) to the HEAD request URL to ensure a fresh response. However this doesn't scale well as we could end up with millions of HEAD requests per day. 

The plan to resolve that is to only execute the HEAD request if it's been more than 5 minutes since the last request. Hence, we will use `LastRequestedStorage` class to facilitate this.

Follow up PRs will execute the plan. 

## How Has This Been Tested?
Added unit tests which uses actual browser LocalStorage. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
