### PR TITLE
Apply expiry approach to file status check

### DIFF
--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -164,12 +164,12 @@ export const StoreFilesMixin = dedupingMixin( base => {
             return fileStatuses.deleted;
           }
 
-          super.log( StoreFiles.LOG_TYPE_WARNING, "File status request error", { url: fileUrl, status: resp.status }, StoreFiles.LOG_AT_MOST_ONCE_PER_DAY );
+          super.log( StoreFiles.LOG_TYPE_WARNING, "File status request error", { url: fileUrl, err: resp.statusText }, StoreFiles.LOG_AT_MOST_ONCE_PER_DAY );
 
           return fileStatuses.fresh;
         }
       }).catch( err => {
-        super.log( StoreFiles.LOG_TYPE_ERROR, "Failed to check file relevancy", { url: fileUrl, err }, StoreFiles.LOG_AT_MOST_ONCE_PER_DAY );
+        super.log( StoreFiles.LOG_TYPE_WARNING, "Failed to check file status", { url: fileUrl, err }, StoreFiles.LOG_AT_MOST_ONCE_PER_DAY );
         return fileStatuses.fresh;
       })
         .finally(() => this.lastRequestedStorage.save( fileUrl, new Date().toUTCString()));
@@ -184,7 +184,7 @@ export const StoreFilesMixin = dedupingMixin( base => {
             respToCache = resp.clone();
             return this._getFileRepresentation( resp );
           } else {
-            return Promise.reject();
+            return Promise.reject( resp.statusText );
           }
         })
         .then( objectURL => {

--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -112,7 +112,6 @@ export const StoreFilesMixin = dedupingMixin( base => {
 
     _handleCachedFile( fileUrl, cache ) {
       return this._getFileStatus( fileUrl, cache ).then( isCacheRelevant => {
-        console.log( "_handleCachedFile", isCacheRelevant );
         switch ( isCacheRelevant ) {
         case fileStatuses.fresh:
           return this._getFileRepresentation( cache );
@@ -136,8 +135,6 @@ export const StoreFilesMixin = dedupingMixin( base => {
       try {
         const lastRequestedDate = new Date( date );
 
-        console.log( "time diff in minutes", Math.floor(( Date.now() - lastRequestedDate.getTime()) / 1000 / 60 ));
-
         return Math.floor(( Date.now() - lastRequestedDate.getTime()) / 1000 / 60 ) > FILE_STATUS_CHECK_EXPIRY;
       } catch ( err ) {
         console.warn( "could not calculate file status check expiry", err );
@@ -154,8 +151,6 @@ export const StoreFilesMixin = dedupingMixin( base => {
 
     _getFileStatus( fileUrl, cachedResponse ) {
       if ( !this._hasFileStatusCheckExpired( fileUrl )) {
-        console.log( "didn't expire" );
-        // TODO: i think theres a problem here
         return Promise.resolve( fileStatuses.fresh );
       }
 
@@ -163,7 +158,6 @@ export const StoreFilesMixin = dedupingMixin( base => {
         method: "HEAD"
       }).then( resp => {
         if ( resp.ok ) {
-          console.log( "comparing etags" );
           return cachedResponse.headers.get( "etag" ) === resp.headers.get( "etag" ) ? fileStatuses.fresh : fileStatuses.stale;
         } else {
           if ( deletedFileStatusCodes.includes( resp.status )) {
@@ -184,8 +178,6 @@ export const StoreFilesMixin = dedupingMixin( base => {
     _requestFile( fileUrl ) {
       let respToCache;
 
-      console.log( "doing a GET request" );
-
       return fetch( fileUrl )
         .then( resp => {
           if ( resp.ok ) {
@@ -196,9 +188,7 @@ export const StoreFilesMixin = dedupingMixin( base => {
           }
         })
         .then( objectURL => {
-          console.log( "putting into cache" )
           super.putCache( respToCache, fileUrl );
-          console.log( "returning object url" );
           return objectURL;
         })
         .catch( err => {
@@ -208,7 +198,6 @@ export const StoreFilesMixin = dedupingMixin( base => {
     }
 
     _getFileRepresentation( resp ) {
-      console.log( "returning file blob" );
       return resp.blob().then( blob => {
         return URL.createObjectURL( blob );
       })

--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -8,7 +8,7 @@ export const StoreFilesMixin = dedupingMixin( base => {
       expiry: 1000 * 60 * 60 * 4
     },
     LOCAL_STORAGE_KEY = "rise_files_last_requested",
-    FILE_STATUS_CHECK_EXPIRY = 5,
+    FILE_STATUS_CHECK_EXPIRY = 10,
     deletedFileStatusCodes = [ 401, 403, 404 ],
     fileStatuses = {
       fresh: "fresh",

--- a/test/unit/store-files-mixin.html
+++ b/test/unit/store-files-mixin.html
@@ -341,23 +341,23 @@
           });
         });
 
-        suite( "_hasFileStatusCheckExpired", () => {
+        suite( "_hasFileStatusCheckExpired", () =>{
           test( "should return true if no saved timestamp exists", () => {
             sinon.stub( storeFilesMixin.lastRequestedStorage, "getTimestamp" ).returns(null);
 
             assert.isTrue( storeFilesMixin._hasFileStatusCheckExpired( "test" ) );
           } );
 
-          test( "should return false if it has not expired (5 mins)", () => {
+          test( "should return false if it has not expired (10 mins)", () => {
             sinon.stub( storeFilesMixin.lastRequestedStorage, "getTimestamp" ).returns("Mon, 29 Jun 2020 15:20:45 GMT");
-            sinon.stub(Date, "now").returns(1593444068515);
+            sinon.stub(Date, "now").returns(1593444525000); // Mon, 29 Jun 2020 15:28:45 GMT
 
             assert.isFalse(storeFilesMixin._hasFileStatusCheckExpired("test"));
           } );
 
-          test( "should return true if it has expired (5 mins)", () => {
+          test( "should return true if it has expired (10 mins)", () => {
             sinon.stub( storeFilesMixin.lastRequestedStorage, "getTimestamp" ).returns("Mon, 29 Jun 2020 15:20:45 GMT");
-            sinon.stub(Date, "now").returns(1593445973598);
+            sinon.stub(Date, "now").returns(1593445973598); // Mon, 29 Jun 2020 15:52:53 GMT
 
             assert.isTrue(storeFilesMixin._hasFileStatusCheckExpired("test"));
           } );

--- a/test/unit/store-files-mixin.html
+++ b/test/unit/store-files-mixin.html
@@ -168,6 +168,28 @@
               done();
             });
           });
+
+          test( "should log a GET request error", (done) => {
+            const response = new Response(null, {
+              statusText: "File not found",
+              status: 404,
+              headers: {}
+            });
+
+            window.fetch.resolves(response);
+
+            storeFilesMixin._requestFile("test.com").then(() => {
+              assert.isTrue( storeFilesMixin.log.calledWith(
+                "error",
+                "Failed to get file from storage",
+                {
+                  url: "test.com",
+                  err: "File not found"
+                }
+              ) );
+              done();
+            });
+          } );
         });
 
         suite( "_getFileStatus", () => {
@@ -246,6 +268,28 @@
             });
           });
 
+          test ( `should return "fresh" and log warning when HEAD request error`, (done) => {
+            const response = new Response(null, {
+              status: 500,
+              statusText: "Server error",
+              headers: {}
+            });
+
+            window.fetch.resolves(response);
+
+            storeFilesMixin._getFileStatus( "url", cachedResponse ).then(() => {
+              assert.isTrue( storeFilesMixin.log.calledWith(
+                "warning",
+                "File status request error",
+                {
+                  url: "url",
+                  err: "Server error"
+                }
+              ) );
+              done();
+            });
+          } );
+
           test( `should return "fresh" with rejection`, (done) => {
             window.fetch.rejects();
 
@@ -260,8 +304,8 @@
 
             storeFilesMixin._getFileStatus( "url", cachedResponse ).then(() => {
               assert.isTrue( storeFilesMixin.log.calledWith(
-                "error",
-                "Failed to check file relevancy",
+                "warning",
+                "Failed to check file status",
               ) );
               done();
             });

--- a/test/unit/store-files-mixin.html
+++ b/test/unit/store-files-mixin.html
@@ -61,8 +61,7 @@
 
           test( "should request the file if cache is unavailable", done => {
             sinon.stub(storeFilesMixin.__proto__, "_requestFile");
-            let stubbedCache = sinon.stub(storeFilesMixin.__proto__.__proto__, "getCache");
-            stubbedCache.resolves(Promise.reject());
+            sinon.stub(storeFilesMixin, "_getCacheCustom").rejects();
 
             storeFilesMixin.getFile().then(() => {
               assert.isTrue(storeFilesMixin._requestFile.called);
@@ -183,6 +182,8 @@
             cachedResponse = new Response(null, {
               headers: { etag: "false" }
             });
+
+            sinon.stub(storeFilesMixin, "_hasFileStatusCheckExpired").returns(true);
           });
 
           test( `for 404 should return "deleted"`, (done) => {

--- a/test/unit/store-files-mixin.html
+++ b/test/unit/store-files-mixin.html
@@ -266,6 +266,16 @@
               done();
             });
           });
+
+          test( `should return "fresh" if file status check has not expired`, (done) => {
+            storeFilesMixin._hasFileStatusCheckExpired.restore();
+            sinon.stub(storeFilesMixin, "_hasFileStatusCheckExpired").returns(false);
+
+            storeFilesMixin._getFileStatus( "url", cachedResponse ).then((res) => {
+              assert.isTrue(res === "fresh");
+              done();
+            });
+          } );
         });
 
         suite( "_getFileRepresentation", () => {
@@ -284,6 +294,40 @@
                 assert.isTrue( URL.createObjectURL.calledWith( "BLOB" ) );
                 done();
               });
+          });
+        });
+
+        suite( "_hasFileStatusCheckExpired", () => {
+          test( "should return true if no saved timestamp exists", () => {
+            sinon.stub( storeFilesMixin.lastRequestedStorage, "getTimestamp" ).returns(null);
+
+            assert.isTrue( storeFilesMixin._hasFileStatusCheckExpired( "test" ) );
+          } );
+
+          test( "should return false if it has not expired (5 mins)", () => {
+            sinon.stub( storeFilesMixin.lastRequestedStorage, "getTimestamp" ).returns("Mon, 29 Jun 2020 15:20:45 GMT");
+            sinon.stub(Date, "now").returns(1593444068515);
+
+            assert.isFalse(storeFilesMixin._hasFileStatusCheckExpired("test"));
+          } );
+
+          test( "should return true if it has expired (5 mins)", () => {
+            sinon.stub( storeFilesMixin.lastRequestedStorage, "getTimestamp" ).returns("Mon, 29 Jun 2020 15:20:45 GMT");
+            sinon.stub(Date, "now").returns(1593445973598);
+
+            assert.isTrue(storeFilesMixin._hasFileStatusCheckExpired("test"));
+          } );
+        } );
+
+        suite("_getUrlWithCacheBuster", () => {
+          test("should append a timestamp cachebuster to url", () => {
+            sinon.stub(Date, "now").returns(1593446178078);
+            assert.equal(storeFilesMixin._getUrlWithCacheBuster( "https://test.com/test.jpg" ), "https://test.com/test.jpg?cb=1593446178078");
+          });
+
+          test("should account for any query params when appending cachebuster", () => {
+            sinon.stub(Date, "now").returns(1593446178078);
+            assert.equal(storeFilesMixin._getUrlWithCacheBuster( "https://test.com/test.jpg?test=test" ), "https://test.com/test.jpg?test=test&cb=1593446178078");
           });
         });
       });


### PR DESCRIPTION
## Description
Previously we were executing a HEAD request to check the status of a cached file (compare etags)  upon **every subsequent `getFile()` call**. This does not scale well.

Now we are applying an expiry approach to retrieving the status of a file to reduce the amount of HEAD requests made - only executing a HEAD request if it has been longer than 5 mins since last time requested. We store the timestamp of last request in LocalStorage (via LastRequestedStorage class). 

Also we add a cachebuster to the HEAD request url to prevent the Browser caching HEAD requests to disk due to GCS setting Cache-Control header on response with a 24 hour expiry. 

Lastly revised and added logs in particular request error and failure scenarios. 

## Motivation and Context
Small incremental steps to caching images and videos in Browser to support Shared Schedules

## How Has This Been Tested?
Tested with https://apps.risevision.com/templates/edit/5dba9780-d656-4999-b2f1-7ce71dda6f64/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f using Charles to locally map to local version of Image component which was built to use modified rise-common-component

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
