### PR TITLE
Enable option for omitting checking cached file status

### DIFF
--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -89,8 +89,12 @@ export const StoreFilesMixin = dedupingMixin( base => {
       this.cacheConfig = Object.assign({}, CACHE_CONFIG );
     }
 
-    getFile( fileUrl ) {
+    getFile( fileUrl, omitCheckingCachedStatus = false ) {
       return this._getCacheCustom( fileUrl ).then( cache => {
+        if ( omitCheckingCachedStatus ) {
+          return Promise.resolve( this._getFileRepresentation( cache ));
+        }
+
         return this._handleCachedFile( fileUrl, cache );
       }).catch(() => {
         return this._requestFile( fileUrl );

--- a/test/unit/store-files-mixin.html
+++ b/test/unit/store-files-mixin.html
@@ -68,6 +68,23 @@
               done();
             });
           });
+
+          test( "should resolve Promise with object url if cache available and 'omitCheckingCachedStatus' flag set", (done) => {
+            const response = new Response(validXmlData,{headers:{date: new Date()}});
+
+            sinon.stub(storeFilesMixin.__proto__, "_handleCachedFile");
+            sinon.stub(storeFilesMixin, "_getFileRepresentation").returns("test object url");
+            sinon.stub(storeFilesMixin, "_getCacheCustom").resolves(Promise.resolve(response));
+
+            storeFilesMixin.getFile("test", true).then((objectUrl) => {
+              assert.equal(objectUrl, "test object url");
+              assert.isFalse(storeFilesMixin._handleCachedFile.called);
+            })
+            .catch((err) => {
+              console.log("shouldn't be here", err);
+              assert.fail();
+            }).finally(() => done());
+          } );
         });
 
         suite( "_handleCachedFile", () => {


### PR DESCRIPTION
## Description
Supporting ability to omit checking a cached files status (HEAD request) and just return the object url representation of the cached file. 

This is to support Image component running on Editor Preview, see PR https://github.com/Rise-Vision/rise-image/pull/78 for more details. 

## Motivation and Context
Small incremental steps to cache files in Browser to support Shared Schedules

## How Has This Been Tested?
In Apps template editor via Charles mapping to local version of Image component that was built to use these changes. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
