### PR TITLE
Enable logging in Shared Schedules

### DIFF
--- a/src/logger-mixin.js
+++ b/src/logger-mixin.js
@@ -38,7 +38,7 @@ export const LoggerMixin = dedupingMixin( base => {
     }
 
     log( type, event, details = null, additionalFields ) {
-      if ( RisePlayerConfiguration.isPreview()) {
+      if ( RisePlayerConfiguration.isPreview() && !RisePlayerConfiguration.Helpers.isSharedSchedule()) {
         return;
       }
 

--- a/test/unit/logger-mixin.html
+++ b/test/unit/logger-mixin.html
@@ -16,11 +16,15 @@
 <body>
 
 <script type="text/javascript">
-  let preview = false;
+  let preview = false,
+    sharedSchedule = false;
 
   RisePlayerConfiguration = {
     Logger: {},
-    isPreview: () => preview
+    isPreview: () => preview,
+    Helpers: {
+      isSharedSchedule: () => sharedSchedule
+    }
   };
 </script>
 
@@ -75,6 +79,11 @@
     });
 
     suite( "log", () => {
+      teardown(() => {
+        preview = false;
+        sharedSchedule = false;
+      });
+
       test( "should call with correct parameters", () => {
         logger.log(Logger.LOG_TYPE_INFO, "event", "details", "additionalFields");
 
@@ -113,18 +122,19 @@
         assert.isFalse( RisePlayerConfiguration.Logger.error.called );
       });
 
-      test( "should log when not in preview", () => {
-        preview = false;
-        logger.log(Logger.LOG_TYPE_INFO);
-
-        assert.isTrue(RisePlayerConfiguration.Logger.info.called);
-      });
-
-      test( "should not log in preview", () => {
+      test( "should not log in preview (if not shared schedules)", () => {
         preview = true;
         logger.log(Logger.LOG_TYPE_INFO);
 
         assert.isFalse(RisePlayerConfiguration.Logger.info.called);
+      });
+
+      test( "should log when in shared schedule", () => {
+        preview = true;
+        sharedSchedule = true;
+        logger.log(Logger.LOG_TYPE_INFO);
+
+        assert.isTrue(RisePlayerConfiguration.Logger.info.called);
       });
     });
 


### PR DESCRIPTION
## Description
Allow components to log when running in Shared Schedules

This change is in collaboration with https://github.com/Rise-Vision/common-template/pull/128 which only allows image and video components to log to BQ. 

## Motivation and Context
Validating image and video in Shared Schedules

## How Has This Been Tested?
Tested in a Shared Schedule and in Template Editor with Charles mapping to local versions of Image and Video component built with these changes as well as local built version of common-template. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
