### PR TITLE
Remove polling cached file status

### DIFF
--- a/src/last-requested-storage-mixin.js
+++ b/src/last-requested-storage-mixin.js
@@ -1,0 +1,73 @@
+import { dedupingMixin } from "@polymer/polymer/lib/utils/mixin.js";
+
+export const LastRequestedStorageMixin = dedupingMixin( base => {
+  const LOCAL_STORAGE_KEY = "rise_files_last_requested";
+
+  class LastRequestedStorage extends base {
+    constructor() {
+      super();
+
+      this._isSupported = this._isLocalStorageSupported();
+    }
+
+    save( fileUrl, timestamp ) {
+      if ( !this._isSupported ) {
+        return;
+      }
+
+      if ( !fileUrl || !timestamp ) {
+        return;
+      }
+
+      const map = this._getMap();
+
+      map.set( fileUrl, timestamp );
+
+      this._saveMap( map );
+    }
+
+    getTimestamp( fileUrl ) {
+      if ( !this._isSupported || !fileUrl ) {
+        return;
+      }
+
+      const map = this._getMap();
+
+      return map.get( fileUrl )
+    }
+
+    _isLocalStorageSupported() {
+      const test = "test";
+
+      try {
+        localStorage.setItem( test, test );
+        localStorage.removeItem( test );
+        return true;
+      } catch ( e ) {
+        return false;
+      }
+    }
+
+    _getMap() {
+      let map;
+
+      try {
+        map = new Map( JSON.parse( localStorage.getItem( LOCAL_STORAGE_KEY )));
+      } catch ( e ) {
+        console.warn( e ); // eslint-disable-line no-console
+        map = new Map();
+      }
+      return map;
+    }
+
+    _saveMap( map ) {
+      if ( !map || !( map instanceof Map )) {
+        return;
+      }
+
+      localStorage.setItem( LOCAL_STORAGE_KEY, JSON.stringify( Array.from( map )));
+    }
+  }
+
+  return LastRequestedStorage;
+})

--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -3,9 +3,7 @@ import { CacheMixin } from "./cache-mixin.js";
 
 export const StoreFilesMixin = dedupingMixin( base => {
   const CACHE_CONFIG = {
-    name: "store-files-mixin",
-    refresh: 1000 * 60 * 60 * 2,
-    expiry: 1000 * 60 * 60 * 4
+    name: "store-files-mixin"
   };
 
   class StoreFiles extends CacheMixin( base ) {

--- a/src/store-files-mixin.js
+++ b/src/store-files-mixin.js
@@ -3,99 +3,21 @@ import { CacheMixin } from "./cache-mixin.js";
 
 export const StoreFilesMixin = dedupingMixin( base => {
   const CACHE_CONFIG = {
-      name: "store-files-mixin",
-      refresh: 1000 * 60 * 60 * 2,
-      expiry: 1000 * 60 * 60 * 4
-    },
-    LOCAL_STORAGE_KEY = "rise_files_last_requested",
-    FILE_STATUS_CHECK_EXPIRY = 10,
-    deletedFileStatusCodes = [ 401, 403, 404 ],
-    fileStatuses = {
-      fresh: "fresh",
-      stale: "stale",
-      deleted: "deleted"
-    };
-
-  class LastRequestedStorage {
-    constructor() {
-      this._isSupported = this._isLocalStorageSupported();
-    }
-
-    save( fileUrl, timestamp ) {
-      if ( !this._isSupported ) {
-        return;
-      }
-
-      if ( !fileUrl || !timestamp ) {
-        return;
-      }
-
-      const map = this._getMap();
-
-      map.set( fileUrl, timestamp );
-
-      this._saveMap( map );
-    }
-
-    getTimestamp( fileUrl ) {
-      if ( !this._isSupported || !fileUrl ) {
-        return;
-      }
-
-      const map = this._getMap();
-
-      return map.get( fileUrl )
-    }
-
-    _isLocalStorageSupported() {
-      const test = "test";
-
-      try {
-        localStorage.setItem( test, test );
-        localStorage.removeItem( test );
-        return true;
-      } catch ( e ) {
-        return false;
-      }
-    }
-
-    _getMap() {
-      let map;
-
-      try {
-        map = new Map( JSON.parse( localStorage.getItem( LOCAL_STORAGE_KEY )));
-      } catch ( e ) {
-        console.warn( e ); // eslint-disable-line no-console
-        map = new Map();
-      }
-      return map;
-    }
-
-    _saveMap( map ) {
-      if ( !map || !( map instanceof Map )) {
-        return;
-      }
-
-      localStorage.setItem( LOCAL_STORAGE_KEY, JSON.stringify( Array.from( map )));
-    }
-  }
-
+    name: "store-files-mixin",
+    refresh: 1000 * 60 * 60 * 2,
+    expiry: 1000 * 60 * 60 * 4
+  };
 
   class StoreFiles extends CacheMixin( base ) {
     constructor() {
       super();
 
-      this.lastRequestedStorage = new LastRequestedStorage();
       this.cacheConfig = Object.assign({}, CACHE_CONFIG );
     }
 
-    getFile( fileUrl, omitCheckingCachedStatus = false ) {
+    getFile( fileUrl ) {
       return this._getCacheCustom( fileUrl ).then( cache => {
-        if ( omitCheckingCachedStatus ) {
-          return Promise.resolve( this._getFileRepresentation( cache ));
-        }
-
-        return this._handleCachedFile( fileUrl, cache );
+        return this._getFileRepresentation( cache );
       }).catch(() => {
         return this._requestFile( fileUrl );
       })
@@ -112,71 +34,6 @@ export const StoreFilesMixin = dedupingMixin( base => {
       }).catch(() => {
         return Promise.reject();
       })
-    }
-
-    _handleCachedFile( fileUrl, cache ) {
-      return this._getFileStatus( fileUrl, cache ).then( isCacheRelevant => {
-        switch ( isCacheRelevant ) {
-        case fileStatuses.fresh:
-          return this._getFileRepresentation( cache );
-        case fileStatuses.stale:
-          return this._requestFile( fileUrl )
-        case fileStatuses.deleted:
-        default:
-          return null;
-        }
-      })
-    }
-
-    _hasFileStatusCheckExpired( fileUrl ) {
-      const date = this.lastRequestedStorage.getTimestamp( fileUrl );
-
-      if ( !date ) {
-        // nothing stored, return as if expired
-        return true;
-      }
-
-      try {
-        const lastRequestedDate = new Date( date );
-
-        return Math.floor(( Date.now() - lastRequestedDate.getTime()) / 1000 / 60 ) > FILE_STATUS_CHECK_EXPIRY;
-      } catch ( err ) {
-        console.warn( "could not calculate file status check expiry", err );
-        return true;
-      }
-    }
-
-    _getUrlWithCacheBuster( url ) {
-      const str = url.split( "?" ),
-        separator = ( str.length === 1 ) ? "?" : "&";
-
-      return `${url}${separator}cb=${Date.now()}`;
-    }
-
-    _getFileStatus( fileUrl, cachedResponse ) {
-      if ( !this._hasFileStatusCheckExpired( fileUrl )) {
-        return Promise.resolve( fileStatuses.fresh );
-      }
-
-      return fetch( this._getUrlWithCacheBuster( fileUrl ), {
-        method: "HEAD"
-      }).then( resp => {
-        if ( resp.ok ) {
-          return cachedResponse.headers.get( "etag" ) === resp.headers.get( "etag" ) ? fileStatuses.fresh : fileStatuses.stale;
-        } else {
-          if ( deletedFileStatusCodes.includes( resp.status )) {
-            return fileStatuses.deleted;
-          }
-
-          super.log( StoreFiles.LOG_TYPE_WARNING, "File status request error", { url: fileUrl, err: resp.statusText }, StoreFiles.LOG_AT_MOST_ONCE_PER_DAY );
-
-          return fileStatuses.fresh;
-        }
-      }).catch( err => {
-        super.log( StoreFiles.LOG_TYPE_WARNING, "Failed to check file status", { url: fileUrl, err }, StoreFiles.LOG_AT_MOST_ONCE_PER_DAY );
-        return fileStatuses.fresh;
-      })
-        .finally(() => this.lastRequestedStorage.save( fileUrl, new Date().toUTCString()));
     }
 
     _requestFile( fileUrl ) {
@@ -198,13 +55,13 @@ export const StoreFilesMixin = dedupingMixin( base => {
         .catch( err => {
           super.log( StoreFiles.LOG_TYPE_ERROR, "Failed to get file from storage", { url: fileUrl, err }, StoreFiles.LOG_AT_MOST_ONCE_PER_DAY );
           return err;
-        })
+        });
     }
 
     _getFileRepresentation( resp ) {
       return resp.blob().then( blob => {
         return URL.createObjectURL( blob );
-      })
+      });
     }
   }
 

--- a/test/index.html
+++ b/test/index.html
@@ -22,7 +22,7 @@
     "unit/valid-files-mixin.html",
     "unit/watch-files-mixin.html",
     "unit/store-files-mixin.html",
-    "unit/store-files-mixin-last-requested.html",
+    "unit/last-requested-storage-mixin.html",
   ] );
 </script>
 </body>

--- a/test/unit/last-requested-storage-mixin.html
+++ b/test/unit/last-requested-storage-mixin.html
@@ -34,14 +34,16 @@
   }
 </script>
 <script type="module">
-  import * as storeFilesModule from '../../src/store-files-mixin.js'
+  import * as lastRequestedStorageModule from '../../src/last-requested-storage-mixin.js';
+
+  const LastRequestedStorage = lastRequestedStorageModule.LastRequestedStorageMixin(class {});
+  let lastRequestedStorage;
 
   suite("last requested storage", () => {
     let lastRequestedStorage;
 
     setup(() => {
-      const StoreFiles = storeFilesModule.StoreFilesMixin(class {});
-      lastRequestedStorage = new StoreFiles().lastRequestedStorage;
+      lastRequestedStorage = new LastRequestedStorage();
 
       createLocalStorageStub();
     });

--- a/test/unit/store-files-mixin.html
+++ b/test/unit/store-files-mixin.html
@@ -47,18 +47,7 @@
           sinon.restore();
         });
 
-        suite( "get", () => {
-          test( "should call cache handler if cache is available and valid", done => {
-            sinon.stub(storeFilesMixin.__proto__, "_handleCachedFile");
-            let stubbedCache = sinon.stub(storeFilesMixin, "_getCacheCustom");
-            stubbedCache.resolves(Promise.resolve());
-
-            storeFilesMixin.getFile().then(() => {
-              assert.isTrue(storeFilesMixin._handleCachedFile.called);
-              done();
-            });
-          });
-
+        suite( "getFile", () => {
           test( "should request the file if cache is unavailable", done => {
             sinon.stub(storeFilesMixin.__proto__, "_requestFile");
             sinon.stub(storeFilesMixin, "_getCacheCustom").rejects();
@@ -69,74 +58,20 @@
             });
           });
 
-          test( "should resolve Promise with object url if cache available and 'omitCheckingCachedStatus' flag set", (done) => {
+          test( "should resolve with object url if cache available", (done) => {
             const response = new Response(validXmlData,{headers:{date: new Date()}});
 
-            sinon.stub(storeFilesMixin.__proto__, "_handleCachedFile");
             sinon.stub(storeFilesMixin, "_getFileRepresentation").returns("test object url");
             sinon.stub(storeFilesMixin, "_getCacheCustom").resolves(Promise.resolve(response));
 
             storeFilesMixin.getFile("test", true).then((objectUrl) => {
               assert.equal(objectUrl, "test object url");
-              assert.isFalse(storeFilesMixin._handleCachedFile.called);
             })
             .catch((err) => {
               console.log("shouldn't be here", err);
               assert.fail();
             }).finally(() => done());
           } );
-        });
-
-        suite( "_handleCachedFile", () => {
-          let response;
-
-          setup(()=>{
-            response = new Response(validXmlData,{headers:{date: new Date()}});
-            URL.createObjectURL = sinon.stub();
-          });
-
-          teardown(() => {
-            sinon.restore();
-          });
-
-          test( `should return file representation for status "fresh"`, (done) => {
-            storeFilesMixin._getFileStatus = sinon.stub().resolves( "fresh" );
-            response.blob = sinon.stub().resolves( "BLOB" );
-
-            storeFilesMixin._handleCachedFile( "url", response ).then((res) => {
-              assert.isTrue( response.blob.called );
-              assert.isTrue( URL.createObjectURL.calledWith( "BLOB" ) );
-              done();
-            });
-          });
-
-          test( `should request a file for status "stale"`, (done) => {
-            storeFilesMixin._getFileStatus = sinon.stub().resolves( "stale" );
-            storeFilesMixin._requestFile = sinon.stub();
-
-            storeFilesMixin._handleCachedFile( "url", response ).then((res) => {
-              assert.isTrue( storeFilesMixin._requestFile.calledWith( "url" ) );
-              done();
-            });
-          });
-
-          test( `should return null for status "deleted"`, (done) => {
-            storeFilesMixin._getFileStatus = sinon.stub().resolves( "deleted" );
-
-            storeFilesMixin._handleCachedFile( "url", response ).then((res) => {
-              assert.isTrue( res === null );
-              done();
-            });
-          });
-
-          test( `should return null for default (status not covered)`, (done) => {
-            storeFilesMixin._getFileStatus = sinon.stub().resolves( "foo bar" );
-
-            storeFilesMixin._handleCachedFile( "url", response ).then((res) => {
-              assert.isTrue( res === null );
-              done();
-            });
-          });
         });
 
         suite( "_requestFile", () => {
@@ -171,7 +106,7 @@
             });
           });
 
-          test( "should cache response and creat objectUrl ", done => {
+          test( "should cache response and create objectUrl ", done => {
             sinon.stub(response, "clone");
             storeFilesMixin.lastRequestedStorage = {
               save: sinon.stub(),
@@ -209,136 +144,6 @@
           } );
         });
 
-        suite( "_getFileStatus", () => {
-          let response;
-          let cachedResponse;
-
-          setup(() => {
-            response = new Response(null, {
-              headers: { etag: "true" }
-            });
-
-            cachedResponse = new Response(null, {
-              headers: { etag: "false" }
-            });
-
-            sinon.stub(storeFilesMixin, "_hasFileStatusCheckExpired").returns(true);
-          });
-
-          test( `for 404 should return "deleted"`, (done) => {
-            const response = new Response(null, {
-              status: 404,
-              headers: {}
-            });
-
-            window.fetch.resolves(response);
-
-            storeFilesMixin._getFileStatus( "url", cachedResponse ).then((res) => {
-              assert.isTrue(res === "deleted");
-              done();
-            });
-          });
-
-          test( `for 403 should return "deleted"`, (done) => {
-            const response = new Response(null, {
-              status: 403,
-              headers: {}
-            });
-
-            window.fetch.resolves(response);
-
-            storeFilesMixin._getFileStatus( "url", cachedResponse ).then((res) => {
-              assert.isTrue(res === "deleted");
-              done();
-            });
-          });
-
-          test( `for 401 should return "deleted"`, (done) => {
-            const response = new Response(null, {
-              status: 401,
-              headers: {}
-            });
-
-            window.fetch.resolves(response);
-
-            storeFilesMixin._getFileStatus( "url", cachedResponse ).then((res) => {
-              assert.isTrue(res === "deleted");
-              done();
-            });
-          });
-
-          test( `should return "fresh" if cache is relevant`, (done) => {
-            window.fetch.resolves(response);
-
-            storeFilesMixin._getFileStatus( "url", response ).then((res) => {
-              assert.isTrue(res === "fresh");
-              done();
-            });
-          });
-
-          test( `should return "stale" if cache is not relevant`, (done) => {
-            window.fetch.resolves(response);
-
-            storeFilesMixin._getFileStatus( "url", cachedResponse ).then((res) => {
-              assert.isTrue(res === "stale");
-              done();
-            });
-          });
-
-          test ( `should return "fresh" and log warning when HEAD request error`, (done) => {
-            const response = new Response(null, {
-              status: 500,
-              statusText: "Server error",
-              headers: {}
-            });
-
-            window.fetch.resolves(response);
-
-            storeFilesMixin._getFileStatus( "url", cachedResponse ).then(() => {
-              assert.isTrue( storeFilesMixin.log.calledWith(
-                "warning",
-                "File status request error",
-                {
-                  url: "url",
-                  err: "Server error"
-                }
-              ) );
-              done();
-            });
-          } );
-
-          test( `should return "fresh" with rejection`, (done) => {
-            window.fetch.rejects();
-
-            storeFilesMixin._getFileStatus( "url", cachedResponse ).then((res) => {
-              assert.isTrue(res === "fresh");
-              done();
-            });
-          });
-
-          test( "should log an error on reject", (done) => {
-            window.fetch.rejects();
-
-            storeFilesMixin._getFileStatus( "url", cachedResponse ).then(() => {
-              assert.isTrue( storeFilesMixin.log.calledWith(
-                "warning",
-                "Failed to check file status",
-              ) );
-              done();
-            });
-          });
-
-          test( `should return "fresh" if file status check has not expired`, (done) => {
-            storeFilesMixin._hasFileStatusCheckExpired.restore();
-            sinon.stub(storeFilesMixin, "_hasFileStatusCheckExpired").returns(false);
-
-            storeFilesMixin._getFileStatus( "url", cachedResponse ).then((res) => {
-              assert.isTrue(res === "fresh");
-              done();
-            });
-          } );
-        });
-
         suite( "_getFileRepresentation", () => {
           let response;
 
@@ -355,40 +160,6 @@
                 assert.isTrue( URL.createObjectURL.calledWith( "BLOB" ) );
                 done();
               });
-          });
-        });
-
-        suite( "_hasFileStatusCheckExpired", () =>{
-          test( "should return true if no saved timestamp exists", () => {
-            sinon.stub( storeFilesMixin.lastRequestedStorage, "getTimestamp" ).returns(null);
-
-            assert.isTrue( storeFilesMixin._hasFileStatusCheckExpired( "test" ) );
-          } );
-
-          test( "should return false if it has not expired (10 mins)", () => {
-            sinon.stub( storeFilesMixin.lastRequestedStorage, "getTimestamp" ).returns("Mon, 29 Jun 2020 15:20:45 GMT");
-            sinon.stub(Date, "now").returns(1593444525000); // Mon, 29 Jun 2020 15:28:45 GMT
-
-            assert.isFalse(storeFilesMixin._hasFileStatusCheckExpired("test"));
-          } );
-
-          test( "should return true if it has expired (10 mins)", () => {
-            sinon.stub( storeFilesMixin.lastRequestedStorage, "getTimestamp" ).returns("Mon, 29 Jun 2020 15:20:45 GMT");
-            sinon.stub(Date, "now").returns(1593445973598); // Mon, 29 Jun 2020 15:52:53 GMT
-
-            assert.isTrue(storeFilesMixin._hasFileStatusCheckExpired("test"));
-          } );
-        } );
-
-        suite("_getUrlWithCacheBuster", () => {
-          test("should append a timestamp cachebuster to url", () => {
-            sinon.stub(Date, "now").returns(1593446178078);
-            assert.equal(storeFilesMixin._getUrlWithCacheBuster( "https://test.com/test.jpg" ), "https://test.com/test.jpg?cb=1593446178078");
-          });
-
-          test("should account for any query params when appending cachebuster", () => {
-            sinon.stub(Date, "now").returns(1593446178078);
-            assert.equal(storeFilesMixin._getUrlWithCacheBuster( "https://test.com/test.jpg?test=test" ), "https://test.com/test.jpg?test=test&cb=1593446178078");
           });
         });
       });


### PR DESCRIPTION
## Description
Ported `LastRequestedStorage` from `StoreFilesMixin` to its own mixin in case it will be useful in the future

Removed all functionality regarding checking a cached files status, which means **no HEAD requests are being made**. Simplified flow is as follows:

- If a file is not in cache, make a GET request for it, continue handling as is
- If a file is in cache, return the Blob ObjectURL representation of that file

## Motivation and Context
Cost impact of polling cached file status via HEAD requests

## How Has This Been Tested?
Tested in Template Editor and Shared Schedules via Charles mapping to locally built version of Image component

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
