### PR TITLE
Remove prevention of logging when running in "preview"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.7.1",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/logger-mixin.js
+++ b/src/logger-mixin.js
@@ -38,10 +38,6 @@ export const LoggerMixin = dedupingMixin( base => {
     }
 
     log( type, event, details = null, additionalFields ) {
-      if ( RisePlayerConfiguration.isPreview()) {
-        return;
-      }
-
       switch ( type ) {
       case "info":
         RisePlayerConfiguration.Logger.info( this.loggerConfig, event, details, additionalFields );

--- a/test/unit/logger-mixin.html
+++ b/test/unit/logger-mixin.html
@@ -112,20 +112,6 @@
         assert.isFalse( RisePlayerConfiguration.Logger.warning.called );
         assert.isFalse( RisePlayerConfiguration.Logger.error.called );
       });
-
-      test( "should log when not in preview", () => {
-        preview = false;
-        logger.log(Logger.LOG_TYPE_INFO);
-
-        assert.isTrue(RisePlayerConfiguration.Logger.info.called);
-      });
-
-      test( "should not log in preview", () => {
-        preview = true;
-        logger.log(Logger.LOG_TYPE_INFO);
-
-        assert.isFalse(RisePlayerConfiguration.Logger.info.called);
-      });
     });
 
     suite( "getStorageFileFormat", () => {


### PR DESCRIPTION
## Description
Allow logger mixin to process a `log` call while running in any endpoint environment.

## Motivation and Context
Enable processing endpoint log calls to `endpoint-event-logs.logs.eventLog` table when running in any endpoint environment. This change **will not** enable logging to the `client-side-events.Display_Events.events` BQ table when running in shared schedule. `RisePlayerConfiguration.Logger` already prevents logs to that BQ table when running in "preview" (as determined by display id), see [here](https://github.com/Rise-Vision/common-template/blob/master/src/rise-logger.js#L226-L235). 

## How Has This Been Tested?
Tested mapping local version of rise-time-date component using changes from this PR. Forced a format error on the instance of rise-time-date component in the HTML of template. Validated no insert into Display_Events.events table and validated the error was logged to endpoint logging.

![image](https://user-images.githubusercontent.com/7407007/104638180-d635a600-5673-11eb-9e40-c0d02358ee1c.png)


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
