### PR TITLE
Handle initializing configured promise and sending event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/rise-element.js
+++ b/src/rise-element.js
@@ -91,13 +91,11 @@ export const RiseElementMixin = dedupingMixin( base => {
           });
         }
 
-        if ( RisePlayerConfiguration.isConfigured()) {
-          this._init();
-        } else {
-          const init = () => this._init();
+        this._init();
 
-          window.addEventListener( "rise-components-ready", init, { once: true });
-        }
+        RisePlayerConfiguration.Helpers.getComponentAsync( this );
+
+        this._sendEvent( RiseElement.EVENT_CONFIGURED );
       }
 
       isOffline() {
@@ -115,8 +113,6 @@ export const RiseElementMixin = dedupingMixin( base => {
         this.addEventListener( RiseElement.EVENT_START, this._handleStart, { once: true });
         this.addEventListener( RiseElement.EVENT_RISE_PRESENTATION_PLAY, this._handleRisePresentationPlay );
         this.addEventListener( RiseElement.EVENT_RISE_PRESENTATION_STOP, this._handleRisePresentationStop );
-
-        this._sendEvent( RiseElement.EVENT_CONFIGURED );
       }
 
       _sendEvent( eventName, detail = {}) {

--- a/test/unit/rise-element.html
+++ b/test/unit/rise-element.html
@@ -14,7 +14,9 @@
 
   <script type="text/javascript">
     RisePlayerConfiguration = {
-      isConfigured: () => false,
+      Helpers: {
+        getComponentAsync: () => {}
+      },
       Viewer: { }
     };
   </script>
@@ -42,10 +44,10 @@
 
       sinon.stub(logger, "initLogger");
       sinon.stub(logger, "log");
+      sinon.stub(RisePlayerConfiguration.Helpers, "getComponentAsync");
     });
 
     teardown(()=>{
-      RisePlayerConfiguration.isConfigured = () => false;
       sinon.restore();
     });
 
@@ -66,31 +68,23 @@
     });
 
     suite( "ready", () => {
-      let stub;
+      test( "should call init, register component and call configured", () => {
+        sinon.stub( element, '_init');
+        sinon.stub(element, "dispatchEvent");
 
-      setup(()=>{
-        stub = sinon.stub( window, "addEventListener" );
-      });
-
-      test( "should listen for rise-components-ready and call init", () => {
         element.ready();
-        assert.isTrue( stub.calledWith('rise-components-ready') );
+
+        assert.isTrue( element._init.calledOnce );
+
+        assert.isTrue( RisePlayerConfiguration.Helpers.getComponentAsync.calledWith(element) );
+
+        assert.equal(element.dispatchEvent.getCall(0).args[0].type, "configured");
       });
 
       test( "should init mixins ", () => {
         element.ready();
 
         assert.isTrue( logger.initLogger.called );
-      });
-
-      test( "should call _init() if  RisePlayerConfiguration is configured", () => {
-        sinon.stub( element, '_init');
-
-        RisePlayerConfiguration.isConfigured = () => true ;
-        element.ready();
-
-        assert.isTrue( element._init.calledOnce );
-        assert.isFalse( stub.calledTwice );
       });
 
       test( "should initiate endpoint application heartbeats", () => {
@@ -148,13 +142,6 @@ sinon.stub();
 
         element._init();
         assert.isTrue(element.addEventListener.calledWith( "start" ));
-      });
-
-      test( "should raise 'configured' event", () => {
-        sinon.stub(element, "dispatchEvent");
-
-        element._init();
-        assert.equal(element.dispatchEvent.getCall(0).args[0].type, "configured");
       });
     });
 


### PR DESCRIPTION
## Description
Handle initializing configured promise and sending event

No longer rely on the handler being initialized
from common-template

Initialize it here instead

## Motivation and Context
Element handles its own initialization

## How Has This Been Tested?
Tested locally and on displays with several updated components. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No