### PR TITLE
Add a new component dist file referencing a static polymer-bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/scripts/deploy-gcs.sh
+++ b/scripts/deploy-gcs.sh
@@ -1,6 +1,6 @@
 COMPONENT_NAME=$1
 TARGET=$2
 
-gsutil cp dist/$COMPONENT_NAME.js $TARGET
+gsutil cp dist/*.js $TARGET
 gsutil -m setmeta -r -h "Cache-Control:private, max-age=600" $TARGET
 gsutil acl -r ch -u AllUsers:R $TARGET

--- a/scripts/extract-source.sh
+++ b/scripts/extract-source.sh
@@ -17,3 +17,5 @@ then
 
   exit 1
 fi
+
+sed 's|../shared_bundle_1.js|https://widgets.risevision.com/stable/common/polymer-bundle.min.js|' $COMPONENT_SOURCE > dist/$1-bundle.min.js


### PR DESCRIPTION
## Description
Add a new component dist file (dist/<component>-bundle.min.js) that references a static polymer-bundle, generated by https://github.com/Rise-Vision/rise-init

## Motivation and Context
Currently, components reference "../shared_bundle_1.js" to load polymer and dependencies like iron-image, dom-if and jsonp-library. That path is relative to the HTML Template, so each template has to build its own ../shared_bundle_1.js and include the dependencies it uses.

But for the Playlist Component implementation, as users can add any visual component, Templates would need to accept any visual component and provide the required dependencies. 

So instead of adding all dependencies into every Template, we are instead changing the reference in the components to a static file. 

The benefit is that we have a single file to update in case we need to add dependencies in the future and we don't need to update existing templates.

## How Has This Been Tested?
I deployed updated versions of rise-text and rise-image and referenced into this sample template: https://storage.googleapis.com/risemedialibrary-554d3ef9-78b7-4726-8f46-c1ec140c166d/html-template-test/index.html

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
