### PR TITLE
Rename two fetch-mixin functions to imply they can be overridden

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.8.4",
+  "version": "1.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1378,14 +1378,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -1880,11 +1872,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
       "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-object": {
       "version": "1.0.4",
@@ -3345,12 +3332,32 @@
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
             "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
             "isobject": "^3.0.1",
             "repeat-element": "^1.1.2",
             "snapdragon": "^0.8.1",
             "snapdragon-node": "^2.0.1",
             "split-string": "^3.0.2",
             "to-regex": "^3.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
           }
         },
         "micromatch": {
@@ -3385,6 +3392,15 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
         }
       }
     },
@@ -3492,14 +3508,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
-      }
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "requires": {
-        "is-number": "^7.0.0"
       }
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -150,8 +150,8 @@ export const FetchMixin = dedupingMixin( base => {
       return Fetch.LOG_TYPE_ERROR;
     }
 
-    _logFetchError( err ) {
-      const details = this._eventDetailFor( err );
+    logFetchError( err ) {
+      const details = this.eventDetailFor( err );
 
       if ( err && err.isOffline ) {
         super.log( Fetch.LOG_TYPE_WARNING, "client offline", null, details );
@@ -171,7 +171,7 @@ export const FetchMixin = dedupingMixin( base => {
       } else {
         this._requestRetryCount = 0;
 
-        this._logFetchError( err );
+        this.logFetchError( err );
 
         this.processError && this.processError( err );
 
@@ -179,7 +179,7 @@ export const FetchMixin = dedupingMixin( base => {
       }
     }
 
-    _eventDetailFor( error ) {
+    eventDetailFor( error ) {
       const detail = { error: error && error.message ? error.message : null };
 
       if ( error && error.status ) {

--- a/test/unit/fetch-mixin-error-type-override.html
+++ b/test/unit/fetch-mixin-error-type-override.html
@@ -45,7 +45,7 @@
       });
 
       test( "should return default log type for any error", () => {
-        element._logFetchError();
+        element.logFetchError();
 
         assert.isTrue(loggerMixin.log.calledOnce);
         assert.equal(loggerMixin.log.lastCall.args[0], "error");
@@ -69,7 +69,7 @@
       });
 
       test( "should return error log type", () => {
-        element._logFetchError({ status: 500 });
+        element.logFetchError({ status: 500 });
 
         assert.isTrue(loggerMixin.log.calledOnce);
         assert.equal(loggerMixin.log.lastCall.args[0], "error");
@@ -77,7 +77,7 @@
       });
 
       test( "should return warning log type", () => {
-        element._logFetchError({ status: 400 });
+        element.logFetchError({ status: 400 });
 
         assert.isTrue(loggerMixin.log.calledOnce);
         assert.equal(loggerMixin.log.lastCall.args[0], "warning");

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -589,27 +589,27 @@
       });
     });
 
-    suite( "_eventDetailFor", () => {
+    suite( "eventDetailFor", () => {
       test( "should get event detail for undefined event", () => {
-        const detail = fetchMixin._eventDetailFor();
+        const detail = fetchMixin.eventDetailFor();
 
         assert.deepEqual( detail, { error: null } );
       });
 
       test( "should get event detail for event with no message", () => {
-        const detail = fetchMixin._eventDetailFor({});
+        const detail = fetchMixin.eventDetailFor({});
 
         assert.deepEqual( detail, { error: null } );
       });
 
       test( "should get event detail for event with message", () => {
-        const detail = fetchMixin._eventDetailFor({ message: "FAIL" });
+        const detail = fetchMixin.eventDetailFor({ message: "FAIL" });
 
         assert.deepEqual( detail, { error: "FAIL" } );
       });
 
       test( "should get event detail for event with message and HTTP status code", () => {
-        const detail = fetchMixin._eventDetailFor({
+        const detail = fetchMixin.eventDetailFor({
           message: "FAIL",
           status: 403
         });
@@ -618,7 +618,7 @@
       });
 
       test( "should get event detail for event with message and response text", () => {
-        const detail = fetchMixin._eventDetailFor({
+        const detail = fetchMixin.eventDetailFor({
           message: "FAIL",
           responseText: "username not found"
         });


### PR DESCRIPTION
## Description
Remove `_` prefix from functions `logFetchError()` and `eventDetailFor()` to imply they are public and can be overridden by a component.

## Motivation and Context
Twitter component needs to execute its own logic of `logFetchError()` so it can log specific error codes according to the error response status. 

While the other components using fetch-mixin (rss and weather) do not require overriding due to different circumstances of the error responses from their API requests, we need to allow future components to override this function for same reasons as Twitter. 

## How Has This Been Tested?
Unit tests. No components already override those functions, so there's nothing to validate. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
