### PR TITLE
Support new content sentinel watch of files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.9.4",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.9.4",
+  "version": "1.10.0",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -111,8 +111,6 @@ export const WatchFilesMixin = dedupingMixin( base => {
     }
 
     startWatch( filesList ) {
-
-
       if ( !filesList ) {
         return Promise.reject();
       }
@@ -135,11 +133,9 @@ export const WatchFilesMixin = dedupingMixin( base => {
         });
 
         this._watchInitiated = true;
-
-        return Promise.resolve( this._watchType );
-      } else {
-        return Promise.resolve( this._watchType );
       }
+
+      return Promise.resolve( this._watchType );
     }
 
     stopWatch() {

--- a/test/unit/watch-files-mixin.html
+++ b/test/unit/watch-files-mixin.html
@@ -34,6 +34,13 @@
       watchSingleFile: (file, handler) => {
         handler({ status: "CURRENT", filePath: file });
       }
+    },
+    Helpers: {
+      useContentSentinel: () => false,
+      isDisplay: () => true
+    },
+    LocalMessaging: {
+      isConnected: () => true
     }
   };
 </script>
@@ -76,11 +83,12 @@
         watchFiles.watchedFileErrorCallback.restore();
       } );
 
-      test( "should handle adding files", () => {
-        watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ], WatchFiles.WATCH_TYPE_RLS );
-
-        assert.equal( watchFiles.watchedFileAddedCallback.callCount, 2 );
-        assert.equal ( watchFiles.managedFiles.length, 2);
+      test( "should handle adding files", (done) => {
+        watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] ).then(() => {
+          assert.equal( watchFiles.watchedFileAddedCallback.callCount, 2 );
+          assert.equal ( watchFiles.managedFiles.length, 2);
+          done();
+        });
       } );
 
       suite( "handle errors", () => {
@@ -92,35 +100,37 @@
           watchFiles.log.restore();
         } );
 
-        test( "should handle file errors", () => {
-          watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ], WatchFiles.WATCH_TYPE_RLS );
-
-          watchFiles._handleSingleFileUpdate( {
-            filePath: "foo.jpg",
-            fileUrl: sampleUrl( "foo.jpg" ),
-            status: "file-error",
-            errorMessage: "Network error",
-            errorDetail: "Detailed network error"
-          } );
-
-          assert.equal( watchFiles.watchedFileErrorCallback.callCount, 1 );
-          assert.deepEqual( watchFiles.log.lastCall.args, [
-            "error",
-            "file-rls-error",
-            { errorCode: "E000000027" },
-            {
+        test( "should handle file errors", (done) => {
+          watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] ).then(() => {
+            watchFiles._handleSingleFileUpdate( {
+              filePath: "foo.jpg",
+              fileUrl: sampleUrl( "foo.jpg" ),
+              status: "file-error",
               errorMessage: "Network error",
-              errorDetail: "Detailed network error",
-              storage: {
-                configuration: "storage file",
-                file_form: "jpg",
-                file_path: "foo.jpg",
-                local_url: sampleUrl( "foo.jpg" )
+              errorDetail: "Detailed network error"
+            } );
+
+            assert.equal( watchFiles.watchedFileErrorCallback.callCount, 1 );
+            assert.deepEqual( watchFiles.log.lastCall.args, [
+              "error",
+              "file-rls-error",
+              { errorCode: "E000000027" },
+              {
+                errorMessage: "Network error",
+                errorDetail: "Detailed network error",
+                storage: {
+                  configuration: "storage file",
+                  file_form: "jpg",
+                  file_path: "foo.jpg",
+                  local_url: sampleUrl( "foo.jpg" )
+                }
               }
-            }
-          ]);
-          assert.equal (watchFiles.managedFiles.length, 1 );
-          assert.equal (watchFiles._managedFilesInError.length, 1 );
+            ]);
+            assert.equal (watchFiles.managedFiles.length, 1 );
+            assert.equal (watchFiles._managedFilesInError.length, 1 );
+
+            done();
+          });
         } );
 
         test( "should handle insufficient disk space errors", () => {
@@ -149,18 +159,20 @@
           ]);
         } );
 
-        test( "should handle deleting files", () => {
-          watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ], WatchFiles.WATCH_TYPE_RLS );
+        test( "should handle deleting files", (done) => {
+          watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] ).then(() => {
+            watchFiles._handleSingleFileUpdate( {
+              filePath: "foo.jpg",
+              fileUrl: sampleUrl( "foo.jpg" ),
+              status: "deleted",
+            } );
 
-          watchFiles._handleSingleFileUpdate( {
-            filePath: "foo.jpg",
-            fileUrl: sampleUrl( "foo.jpg" ),
-            status: "deleted",
-          } );
+            assert.equal( watchFiles.watchedFileDeletedCallback.callCount, 1 );
+            assert.equal( watchFiles.managedFiles.length, 1);
+            assert.equal( watchFiles._managedFilesInError.length, 0);
 
-          assert.equal( watchFiles.watchedFileDeletedCallback.callCount, 1 );
-          assert.equal( watchFiles.managedFiles.length, 1);
-          assert.equal( watchFiles._managedFilesInError.length, 0);
+            done();
+          });
         } );
 
         test( "should handle deleted file error", () => {
@@ -214,78 +226,98 @@
           }, delays[file]) ;
         } );
 
-        watchFiles.startWatch( [ "a.jpg", "b.jpg", "c.jpg" ], WatchFiles.WATCH_TYPE_RLS );
+        watchFiles.startWatch( [ "a.jpg", "b.jpg", "c.jpg" ] ).then(() => {
+          setTimeout( () => {
+            const addedCalls = watchFiles.watchedFileAddedCallback.getCalls();
 
-        setTimeout( () => {
-          const addedCalls = watchFiles.watchedFileAddedCallback.getCalls();
+            assert.isTrue( addedCalls[0].calledWithExactly( { filePath: "c.jpg" } ) );
+            assert.isTrue( addedCalls[1].calledWithExactly( { filePath: "a.jpg" } ) );
+            assert.isTrue( addedCalls[2].calledWithExactly( { filePath: "b.jpg" } ) );
 
-          assert.isTrue( addedCalls[0].calledWithExactly( { filePath: "c.jpg" } ) );
-          assert.isTrue( addedCalls[1].calledWithExactly( { filePath: "a.jpg" } ) );
-          assert.isTrue( addedCalls[2].calledWithExactly( { filePath: "b.jpg" } ) );
+            assert.equal( watchFiles.getManagedFile( "a.jpg" ).order, 0);
+            assert.equal( watchFiles.getManagedFile( "b.jpg" ).order, 1);
+            assert.equal( watchFiles.getManagedFile( "c.jpg" ).order, 2);
 
-          assert.equal( watchFiles.getManagedFile( "a.jpg" ).order, 0);
-          assert.equal( watchFiles.getManagedFile( "b.jpg" ).order, 1);
-          assert.equal( watchFiles.getManagedFile( "c.jpg" ).order, 2);
-
-          RisePlayerConfiguration.LocalStorage.watchSingleFile.restore();
-          done();
-        }, maxDelay );
+            RisePlayerConfiguration.LocalStorage.watchSingleFile.restore();
+            done();
+          }, maxDelay );
+        });
       } );
     } );
 
     suite( "startWatch", () => {
-      test( "should initialize properties", () => {
+      test( "should initialize properties and resolve with watch type", (done) => {
         const files = [ "a.jpg", "b.jpg" ];
 
-        watchFiles.startWatch( files, WatchFiles.WATCH_TYPE_RLS );
+        watchFiles.startWatch( files ).then((watchType) => {
+          assert.deepEqual( watchFiles._filesList, files );
+          assert.isTrue( watchFiles._watchInitiated );
+          assert.equal( watchType, WatchFiles.WATCH_TYPE_RLS );
+          assert.equal( watchFiles.managedFiles.length, 2);
 
-        assert.deepEqual( watchFiles._filesList, files );
-        assert.isTrue( watchFiles._watchInitiated );
-        assert.equal( watchFiles._watchType, WatchFiles.WATCH_TYPE_RLS );
-        assert.equal( watchFiles.managedFiles.length, 2);
+          watchFiles.stopWatch();
 
-        watchFiles.stopWatch();
+          RisePlayerConfiguration.Helpers.useContentSentinel = () => { return true; }
 
-        watchFiles.startWatch( files, WatchFiles.WATCH_TYPE_SENTINEL );
-        assert.deepEqual( watchFiles._filesList, files );
-        assert.isTrue( watchFiles._watchInitiated );
-        assert.equal( watchFiles._watchType, WatchFiles.WATCH_TYPE_SENTINEL );
-        assert.equal( watchFiles.managedFiles.length, 2);
+          watchFiles.startWatch( files ).then((watchType) => {
+            assert.deepEqual( watchFiles._filesList, files );
+            assert.isTrue( watchFiles._watchInitiated );
+            assert.equal( watchType, WatchFiles.WATCH_TYPE_SENTINEL );
+            assert.equal( watchFiles.managedFiles.length, 2);
+
+            RisePlayerConfiguration.Helpers.useContentSentinel = () => { return false; }
+
+            done();
+          });
+
+        });
       } );
 
-      test( "should not reinitialize if watch has already been initiated", () => {
+      test( "should not reinitialize if watch has already been initiated", (done) => {
         let managedFiles;
 
-        watchFiles.startWatch( [ "a.jpg", "b.jpg" ], WatchFiles.WATCH_TYPE_RLS );
-        managedFiles = watchFiles.managedFiles.slice();
-        watchFiles.startWatch( [ "c.jpg", "d.jpg" ], WatchFiles.WATCH_TYPE_RLS );
-
-        assert.deepEqual( watchFiles.managedFiles, managedFiles);
+        watchFiles.startWatch( [ "a.jpg", "b.jpg" ] ).then(() => {
+          managedFiles = watchFiles.managedFiles.slice();
+          watchFiles.startWatch( [ "c.jpg", "d.jpg" ] ).then(() => {
+            assert.deepEqual( watchFiles.managedFiles, managedFiles);
+            done();
+          });
+        });
       });
 
-      test( "should not execute if params invalid", () => {
+      test( "should reject if params invalid", (done) => {
+        watchFiles.startWatch().catch(() => {
+          assert.isFalse( watchFiles._watchInitiated );
+          done();
+        });
+      } );
+
+      test( "should reject if no watch type can be used", (done) => {
         const files = [ "a.jpg", "b.jpg" ];
 
-        watchFiles.startWatch();
-        assert.isFalse( watchFiles._watchInitiated );
+        RisePlayerConfiguration.LocalMessaging.isConnected = () => { return false; }
 
-        watchFiles.startWatch( files );
-        assert.isFalse( watchFiles._watchInitiated );
+        watchFiles.startWatch( files ).catch(() => {
+          assert.isFalse( watchFiles._watchInitiated );
 
-        watchFiles.startWatch( files, "test" );
-        assert.isFalse( watchFiles._watchInitiated );
-      } )
+          RisePlayerConfiguration.LocalMessaging.isConnected = () => { return true; }
+          done();
+        });
+      } );
     } );
 
     suite( "stopWatch", () => {
-      test( "should reset properties", () => {
-        watchFiles.startWatch( [ "a.jpg", "b.jpg" ], WatchFiles.WATCH_TYPE_RLS );
-        watchFiles.stopWatch();
+      test( "should reset properties", (done) => {
+        watchFiles.startWatch( [ "a.jpg", "b.jpg" ] ).then(() => {
+          watchFiles.stopWatch();
 
-        assert.isFalse( watchFiles._watchInitiated );
-        assert.isEmpty( watchFiles.managedFiles );
-        assert.isEmpty( watchFiles._filesList );
-        assert.isNull( watchFiles._watchType );
+          assert.isFalse( watchFiles._watchInitiated );
+          assert.isEmpty( watchFiles.managedFiles );
+          assert.isEmpty( watchFiles._filesList );
+          assert.isNull( watchFiles._watchType );
+
+          done();
+        });
       } );
     } );
   } );

--- a/test/unit/watch-files-mixin.html
+++ b/test/unit/watch-files-mixin.html
@@ -29,6 +29,11 @@
       watchSingleFile: (file, handler) => {
         handler({ status: "CURRENT", filePath: file, fileUrl: sampleUrl( file ) });
       }
+    },
+    ContentSentinel: {
+      watchSingleFile: (file, handler) => {
+        handler({ status: "CURRENT", filePath: file });
+      }
     }
   };
 </script>
@@ -72,7 +77,7 @@
       } );
 
       test( "should handle adding files", () => {
-        watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] );
+        watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ], WatchFiles.WATCH_TYPE_RLS );
 
         assert.equal( watchFiles.watchedFileAddedCallback.callCount, 2 );
         assert.equal ( watchFiles.managedFiles.length, 2);
@@ -88,7 +93,7 @@
         } );
 
         test( "should handle file errors", () => {
-          watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] );
+          watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ], WatchFiles.WATCH_TYPE_RLS );
 
           watchFiles._handleSingleFileUpdate( {
             filePath: "foo.jpg",
@@ -145,7 +150,7 @@
         } );
 
         test( "should handle deleting files", () => {
-          watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] );
+          watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ], WatchFiles.WATCH_TYPE_RLS );
 
           watchFiles._handleSingleFileUpdate( {
             filePath: "foo.jpg",
@@ -209,7 +214,7 @@
           }, delays[file]) ;
         } );
 
-        watchFiles.startWatch( [ "a.jpg", "b.jpg", "c.jpg" ] );
+        watchFiles.startWatch( [ "a.jpg", "b.jpg", "c.jpg" ], WatchFiles.WATCH_TYPE_RLS );
 
         setTimeout( () => {
           const addedCalls = watchFiles.watchedFileAddedCallback.getCalls();
@@ -232,32 +237,55 @@
       test( "should initialize properties", () => {
         const files = [ "a.jpg", "b.jpg" ];
 
-        watchFiles.startWatch( files );
+        watchFiles.startWatch( files, WatchFiles.WATCH_TYPE_RLS );
 
         assert.deepEqual( watchFiles._filesList, files );
         assert.isTrue( watchFiles._watchInitiated );
+        assert.equal( watchFiles._watchType, WatchFiles.WATCH_TYPE_RLS );
+        assert.equal( watchFiles.managedFiles.length, 2);
+
+        watchFiles.stopWatch();
+
+        watchFiles.startWatch( files, WatchFiles.WATCH_TYPE_SENTINEL );
+        assert.deepEqual( watchFiles._filesList, files );
+        assert.isTrue( watchFiles._watchInitiated );
+        assert.equal( watchFiles._watchType, WatchFiles.WATCH_TYPE_SENTINEL );
         assert.equal( watchFiles.managedFiles.length, 2);
       } );
 
       test( "should not reinitialize if watch has already been initiated", () => {
         let managedFiles;
 
-        watchFiles.startWatch( [ "a.jpg", "b.jpg" ] );
+        watchFiles.startWatch( [ "a.jpg", "b.jpg" ], WatchFiles.WATCH_TYPE_RLS );
         managedFiles = watchFiles.managedFiles.slice();
-        watchFiles.startWatch( [ "c.jpg", "d.jpg" ] );
+        watchFiles.startWatch( [ "c.jpg", "d.jpg" ], WatchFiles.WATCH_TYPE_RLS );
 
         assert.deepEqual( watchFiles.managedFiles, managedFiles);
       });
+
+      test( "should not execute if params invalid", () => {
+        const files = [ "a.jpg", "b.jpg" ];
+
+        watchFiles.startWatch();
+        assert.isFalse( watchFiles._watchInitiated );
+
+        watchFiles.startWatch( files );
+        assert.isFalse( watchFiles._watchInitiated );
+
+        watchFiles.startWatch( files, "test" );
+        assert.isFalse( watchFiles._watchInitiated );
+      } )
     } );
 
     suite( "stopWatch", () => {
       test( "should reset properties", () => {
-        watchFiles.startWatch( [ "a.jpg", "b.jpg" ] );
+        watchFiles.startWatch( [ "a.jpg", "b.jpg" ], WatchFiles.WATCH_TYPE_RLS );
         watchFiles.stopWatch();
 
         assert.isFalse( watchFiles._watchInitiated );
         assert.isEmpty( watchFiles.managedFiles );
         assert.isEmpty( watchFiles._filesList );
+        assert.isNull( watchFiles._watchType );
       } );
     } );
   } );


### PR DESCRIPTION
## Description
Support watching files via `RisePlayerConfiguration.ContentSentinel` (see PR https://github.com/Rise-Vision/common-template/pull/190).

Main differentiation between RLS and ContentSentinel in this mixin is the function to call in RisePlayerConfiguration. All execution and handling for each watch type is the same.

The only other differentiation is messages facilitated via `RisePlayerConfiguration.LocalStorage` provide a `fileUrl` and a value, where as `RisePlayerConfiguration.ContentSentinel` will not. The mixin will propogate `fileUrl` anyway even if value is undefined. The components using the mixin (_rise-image_ or _rise-video_) will be aware of this based on the watch type it is executing. 

## Motivation and Context
Image component caches files in Browser

## How Has This Been Tested?
Only unit tests. Manual tests and validation coming soon ...

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
