### PR TITLE
Log unique error code for FILE-ERROR when content sentinel used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3361,12 +3361,12 @@
           }
         },
         "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
           "requires": {
             "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
+            "picomatch": "^2.2.3"
           },
           "dependencies": {
             "braces": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -160,14 +160,19 @@ export const WatchFilesMixin = dedupingMixin( base => {
         }, {
           name: "file-rls-error",
           code: "E000000027"
+        }, {
+          name: "file-content-sentinel-error",
+          code: "E000000215"
         } ];
 
       let error;
 
       if ( isFileNotFound ) {
         error = errors[ 0 ];
+      } else if ( message.errorMessage && message.errorMessage.toLowerCase().includes( "insufficient disk space" )) {
+        error = errors[ 1 ];
       } else {
-        error = message.errorMessage === "Insufficient disk space" ? errors[ 1 ] : errors[ 2 ];
+        error = this._watchType === WatchFiles.WATCH_TYPE_RLS ? errors[ 2 ] : errors[ 3 ];
       }
 
       // prevent repetitive logging when component instance is receiving messages from other potential component instances watching same file
@@ -189,6 +194,7 @@ export const WatchFilesMixin = dedupingMixin( base => {
        */
 
       this.log( WatchFiles.LOG_TYPE_ERROR, error.name, { errorCode: error.code }, {
+        watchType: this._watchType,
         errorMessage: message.errorMessage,
         errorDetail: message.errorDetail,
         storage: super.getStorageData( filePath, fileUrl ) });

--- a/test/unit/watch-files-mixin.html
+++ b/test/unit/watch-files-mixin.html
@@ -100,7 +100,7 @@
           watchFiles.log.restore();
         } );
 
-        test( "should handle file errors", (done) => {
+        test( "should handle RLS file error", (done) => {
           watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] ).then(() => {
             watchFiles._handleSingleFileUpdate( {
               filePath: "foo.jpg",
@@ -116,6 +116,7 @@
               "file-rls-error",
               { errorCode: "E000000027" },
               {
+                watchType: "rise-local-storage",
                 errorMessage: "Network error",
                 errorDetail: "Detailed network error",
                 storage: {
@@ -128,6 +129,44 @@
             ]);
             assert.equal (watchFiles.managedFiles.length, 1 );
             assert.equal (watchFiles._managedFilesInError.length, 1 );
+
+            done();
+          });
+        } );
+
+        test( "should handle Content Sentinel file error", (done) => {
+          RisePlayerConfiguration.Helpers.useContentSentinel = () => { return true; }
+
+          watchFiles.startWatch( [ "foo.jpg", "bar.jpg" ] ).then(() => {
+            watchFiles._handleSingleFileUpdate( {
+              filePath: "foo.jpg",
+              fileUrl: sampleUrl( "foo.jpg" ),
+              status: "file-error",
+              errorMessage: "Network error",
+              errorDetail: "Detailed network error"
+            } );
+
+            assert.equal( watchFiles.watchedFileErrorCallback.callCount, 1 );
+            assert.deepEqual( watchFiles.log.lastCall.args, [
+              "error",
+              "file-content-sentinel-error",
+              { errorCode: "E000000215" },
+              {
+                watchType: "rise-content-sentinel",
+                errorMessage: "Network error",
+                errorDetail: "Detailed network error",
+                storage: {
+                  configuration: "storage file",
+                  file_form: "jpg",
+                  file_path: "foo.jpg",
+                  local_url: sampleUrl( "foo.jpg" )
+                }
+              }
+            ]);
+            assert.equal (watchFiles.managedFiles.length, 1 );
+            assert.equal (watchFiles._managedFilesInError.length, 1 );
+
+            RisePlayerConfiguration.Helpers.useContentSentinel = () => { return false; }
 
             done();
           });
@@ -147,6 +186,7 @@
             "file-insufficient-disk-space-error",
             { errorCode: "E000000040" },
             {
+              watchType: null,
               errorMessage: "Insufficient disk space",
               errorDetail: "",
               storage: {
@@ -187,6 +227,7 @@
             "file-not-found",
             { errorCode: "E000000014" },
             {
+              watchType: null,
               errorMessage: undefined,
               errorDetail: undefined,
               storage: {


### PR DESCRIPTION
## Description
For watching files, now logging new code `E000000215` when a FILE-ERROR message is received and specifically Content Sentinel is being used for watching files. 

Also including the `watchType` value as additional debug info for confirmation when investigating logs

## Motivation and Context
Logs are indicating `E000000027` is being reported from endpoints where RLS would not be running therefore adding confusion to investigation and what is defined in Error Definitions for `E000000027`

## How Has This Been Tested?
Unit tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
