### PR TITLE
Fix logic that prevents logging duplicate errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -40,7 +40,7 @@ export const WatchFilesMixin = dedupingMixin( base => {
     watchedFileErrorCallback() {}
 
     _manageFileInError( details, fixed ) {
-      const { filePath, params } = details;
+      const { filePath } = details;
 
       if ( !filePath ) {
         return;
@@ -48,17 +48,14 @@ export const WatchFilesMixin = dedupingMixin( base => {
 
       let fileInError = this._getManagedFileInError( filePath );
 
-      if ( fixed && fileInError ) {
+      if ( fileInError ) {
         // remove this file from files in error list
         this._managedFilesInError.splice( this._managedFilesInError.findIndex( file => file.filePath === filePath ), 1 );
-      } else if ( !fixed ) {
-        if ( !fileInError ) {
-          fileInError = { filePath, params };
-          // add this file to list of files in error
-          this._managedFilesInError.push( fileInError );
-        } else {
-          fileInError.params = params;
-        }
+      }
+
+      // if not fixed, then add it to the list
+      if ( !fixed ) {
+        this._managedFilesInError.push( details );
       }
     }
 
@@ -178,7 +175,7 @@ export const WatchFilesMixin = dedupingMixin( base => {
       // prevent repetitive logging when component instance is receiving messages from other potential component instances watching same file
       // Note: to avoid using Lodash or Underscore library for just a .isEqual() function, taking a simple approach to object comparison with JSON.stringify()
       // as the property order will not change and the data is not large for this object
-      if ( fileInError && ( JSON.stringify( details ) === JSON.stringify( fileInError.details ))) {
+      if ( fileInError && ( JSON.stringify( details ) === JSON.stringify( fileInError ))) {
         return;
       }
 


### PR DESCRIPTION
## Description

The logic around `fileInError` was totally broken. 
- We expect the `details` to have `params` field [here](https://github.com/Rise-Vision/rise-common-component/compare/stage/fix-duplicate-error?expand=1#diff-a68527ff1ca3585485c66497e290c037ad0113f352ca9c4e10152ecaf70ced5cL43) , but it only has 'filePath, errorMessage, errorDetail` see [here](https://github.com/Rise-Vision/rise-common-component/blob/3da05a73a2672378110f8c03f7f9d70ec4713ac8/src/watch-files-mixin.js#L148)
- When comparing objects, we expect `fileInError` to have `details` field [here](https://github.com/Rise-Vision/rise-common-component/compare/stage/fix-duplicate-error?expand=1#diff-a68527ff1ca3585485c66497e290c037ad0113f352ca9c4e10152ecaf70ced5cL176), but it does not exist.

I decided to keep the `JSON.stringify` objects comparison. It's not ideal, but considering that we contract the `details` objects ourselves [here](https://github.com/Rise-Vision/rise-common-component/blob/3da05a73a2672378110f8c03f7f9d70ec4713ac8/src/watch-files-mixin.js#L148) and then save it to the list without modification, I think it's okay to use `JSON.stringify`.

One thing to mention is that in-spite of this fix I still see the duplicate errors being logged. There are two reasons for that:
1) **The main reason is that content sentinel sends "FILE-ERROR" first and that results in the file being added to the `_managedFilesInError`, but then, all of a sudden, it sends "FILE-UPDATE" with status "STALE" which causes file to be removed from the `_managedFilesInError`. On the next schedule cycle the "FILE-ERROR" is sent again and error is logged again because `_managedFilesInError` is now empty.**
2) Each instance of the `rise-image` has its own `_managedFilesInError` list.

## Motivation and Context
Prevents logging duplicate errors. Partial fix for https://github.com/Rise-Vision/rise-image/issues/102

## How Has This Been Tested?
Tested with rise-image that was build referencing this change. Then used proxy to load local version of the image.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
