### PR TITLE
Clone response correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -70,9 +70,9 @@ export const FetchMixin = dedupingMixin( base => {
       return this._tryGetCache().then( resp => {
         this._logData( true );
 
-        this._processData( Object.assign( resp.clone(), { isCached: true }));
+        this._processData( Object.assign( this._cloneResponse( resp ), { isCached: true }));
       }).catch(( cachedResp ) => {
-        cachedResp = cachedResp && cachedResp.clone ? Object.assign( cachedResp.clone(), { isCached: true }) : null;
+        cachedResp = cachedResp && cachedResp.clone ? Object.assign( this._cloneResponse( cachedResp ), { isCached: true }) : null;
 
         this._requestData( cachedResp );
       });
@@ -200,6 +200,20 @@ export const FetchMixin = dedupingMixin( base => {
       }
 
       return this._requestRetryCount < this.fetchConfig.count;
+    }
+
+    _cloneResponse( response ) {
+
+      const result = response.clone();
+
+      // If response was created manually using new Response() and
+      // response.url was assigned using Object.defineProperty,
+      // then response.clone() won't clone the "url" property.
+      if ( !result.url && response.url ) {
+        Object.defineProperty( result, "url", { value: response.url });
+      }
+
+      return result;
     }
 
   }

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -114,13 +114,16 @@
 
     suite( "_getData", () => {
       test( "should get the result from cache", done => {
-        cacheMixin.getCache = sinon.stub().resolves( new Response("text") );
+        const response = new Response("text");
+        Object.defineProperty( response, "url", { value: "www.risevision.com" });
+        cacheMixin.getCache = sinon.stub().resolves( response );
         sinon.stub(fetchMixin, "_requestData");
 
         fetchMixin._getData().then(() => {
           assert.isTrue( cacheMixin.getCache.called );
           assert.isTrue( handleResponse.called );
           assert.isFalse( fetchMixin._requestData.called );
+          assert.equal( handleResponse.getCall(0).args[0].url, "www.risevision.com" );
 
           handleResponse.getCall(0).args[0].text().then( text => {
             assert.equal( text, "text" );


### PR DESCRIPTION
## Description
Fix for https://github.com/Rise-Vision/html-template-library/issues/1941. In fact, this is also a correct fix for https://github.com/Rise-Vision/rise-data-weather/pull/89.

The issue occurs when Chrome OS player loads a template over HTTP. In this case CacheStorage is disabled and component falls back on using LocalStorage. Unlike CacheStorage, the LocalStorage cannot save the Response object natively, so the object has to be serialized. When loading Response from cache, the Response object is re-created using `new Response` constructor and then `url` property is assigned using `Object.defineProperty` see [here](https://github.com/Rise-Vision/rise-common-component/blob/8239c6079cf3d7ec75ec6aa768282d2f983c2fab/src/cache-mixin.js#L52). After that the `Response.clone()` can no longer clone the `url` property. This PR adds the `_cloneResponse` method that ensures that `url` property is cloned.

## Motivation and Context
- Issue https://github.com/Rise-Vision/html-template-library/issues/1941

## How Has This Been Tested?
- Unit test
- Tested on local machine using proxy and rise-data-weather component.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
