### PR TITLE
Support duplicate files in watch file list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3313,6 +3313,36 @@
                 "snapdragon-node": "^2.0.1",
                 "split-string": "^3.0.2",
                 "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "fill-range": {
+                  "version": "4.0.0",
+                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                  "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                  "requires": {
+                    "extend-shallow": "^2.0.1",
+                    "is-number": "^3.0.0",
+                    "repeat-string": "^1.6.1",
+                    "to-regex-range": "^2.1.0"
+                  }
+                },
+                "is-number": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                  "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  }
+                },
+                "to-regex-range": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                  "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                  "requires": {
+                    "is-number": "^3.0.0",
+                    "repeat-string": "^1.6.1"
+                  }
+                }
               }
             },
             "fill-range": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -94,7 +94,6 @@ export const WatchFilesMixin = dedupingMixin( base => {
       }
 
       if ( status.toUpperCase() === "DELETED" && managedFile ) {
-        //this.managedFiles.splice( this.managedFiles.findIndex( file => file.filePath === filePath ), 1 );
         this.managedFiles = this.managedFiles.filter( file => file.filePath !== filePath );
       }
 

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -39,6 +39,15 @@ export const WatchFilesMixin = dedupingMixin( base => {
 
     watchedFileErrorCallback() {}
 
+    _getAllIndexesOfFile( arr, filePath ) {
+      return arr.reduce(( indexes, val, index ) => {
+        if ( val === filePath ) {
+          indexes.push( index );
+        }
+        return indexes;
+      }, []);
+    }
+
     _manageFileInError( details, fixed ) {
       const { filePath } = details;
 
@@ -66,21 +75,27 @@ export const WatchFilesMixin = dedupingMixin( base => {
 
       if ( status.toUpperCase() === "CURRENT" ) {
         if ( !managedFile ) {
-          // get the order that this file should be in from _filesList
-          const order = this._filesList.findIndex( path => path === filePath );
+          // get all index values of this file from _filesList
+          const indexes = this._getAllIndexesOfFile( this._filesList, filePath );
 
-          managedFile = { filePath, fileUrl, order };
+          indexes.forEach(( index ) => {
+            this.managedFiles.push({ filePath, fileUrl, order: index });
+          });
 
-          // add this file to list
-          this.managedFiles.push( managedFile );
+          managedFile = this.getManagedFile( filePath );
         } else {
           // file has been updated
-          managedFile.fileUrl = fileUrl;
+          this.managedFiles.forEach(( file ) => {
+            if ( file.filePath === filePath ) {
+              file.fileUrl = fileUrl;
+            }
+          });
         }
       }
 
       if ( status.toUpperCase() === "DELETED" && managedFile ) {
-        this.managedFiles.splice( this.managedFiles.findIndex( file => file.filePath === filePath ), 1 );
+        //this.managedFiles.splice( this.managedFiles.findIndex( file => file.filePath === filePath ), 1 );
+        this.managedFiles = this.managedFiles.filter( file => file.filePath !== filePath );
       }
 
       // sort the managed files based on order value

--- a/test/unit/watch-files-mixin.html
+++ b/test/unit/watch-files-mixin.html
@@ -278,6 +278,13 @@
         watchFiles.watchedFileAddedCallback.restore();
       } );
 
+      test( "_getAllIndexesOfFile() should return array of indexes with provided filePath", () => {
+        assert.deepEqual(watchFiles._getAllIndexesOfFile([]), []);
+        assert.deepEqual(watchFiles._getAllIndexesOfFile([], "test.jpg"), []);
+        assert.deepEqual(watchFiles._getAllIndexesOfFile(["test1.png", "test2.png", "test3.png"], "test2.png"), [1]);
+        assert.deepEqual(watchFiles._getAllIndexesOfFile(["test1.png", "test2.png", "test1.png", "test3.png"], "test1.png"), [0, 2]);
+      } )
+
       test( "should preserve order of files that come in out of order", done => {
         const delays = {
           "a.jpg": 50,
@@ -303,6 +310,46 @@
             assert.equal( watchFiles.getManagedFile( "a.jpg" ).order, 0);
             assert.equal( watchFiles.getManagedFile( "b.jpg" ).order, 1);
             assert.equal( watchFiles.getManagedFile( "c.jpg" ).order, 2);
+
+            RisePlayerConfiguration.LocalStorage.watchSingleFile.restore();
+            done();
+          }, maxDelay );
+        });
+      } );
+
+      test( "should handle file duplicates and order correctly", done => {
+        const delays = {
+          "a.jpg": 50,
+          "b.jpg": 100,
+          "c.jpg": 0
+        };
+        const maxDelay = 100;
+
+        sinon.stub( RisePlayerConfiguration.LocalStorage, "watchSingleFile" ).callsFake( (file, handler) => {
+          setTimeout( () => {
+            handler( { status: "CURRENT", filePath: file, fileUrl: sampleUrl( file ) } );
+          }, delays[file]) ;
+        } );
+
+        watchFiles.startWatch( [ "a.jpg", "b.jpg", "a.jpg", "c.jpg", "b.jpg", "a.jpg", "c.jpg" ] ).then(() => {
+          setTimeout( () => {
+            const addedCalls = watchFiles.watchedFileAddedCallback.getCalls();
+
+            assert.isTrue( addedCalls[0].calledWithExactly( { filePath: "c.jpg" } ) );
+            assert.isTrue( addedCalls[1].calledWithExactly( { filePath: "c.jpg" } ) );
+            assert.isTrue( addedCalls[2].calledWithExactly( { filePath: "a.jpg" } ) );
+            assert.isTrue( addedCalls[3].calledWithExactly( { filePath: "a.jpg" } ) );
+            assert.isTrue( addedCalls[4].calledWithExactly( { filePath: "a.jpg" } ) );
+            assert.isTrue( addedCalls[5].calledWithExactly( { filePath: "b.jpg" } ) );
+            assert.isTrue( addedCalls[6].calledWithExactly( { filePath: "b.jpg" } ) );
+
+            assert.equal( watchFiles.managedFiles[0].filePath, "a.jpg");
+            assert.equal( watchFiles.managedFiles[1].filePath, "b.jpg");
+            assert.equal( watchFiles.managedFiles[2].filePath, "a.jpg");
+            assert.equal( watchFiles.managedFiles[3].filePath, "c.jpg");
+            assert.equal( watchFiles.managedFiles[4].filePath, "b.jpg");
+            assert.equal( watchFiles.managedFiles[5].filePath, "a.jpg");
+            assert.equal( watchFiles.managedFiles[6].filePath, "c.jpg");
 
             RisePlayerConfiguration.LocalStorage.watchSingleFile.restore();
             done();


### PR DESCRIPTION
## Description
Support duplicate files in the list of files provided to `startWatch()` function. 

Ensure the `managedFiles` list includes the duplicates and the order is preserved exactly as provided in `startWatch`. 

## Motivation and Context
Issue https://github.com/Rise-Vision/rise-image/issues/109

## How Has This Been Tested?
Unit tests added. Full validation will be done in Image & Video components when they are updated to use this new release. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
no
