### PR TITLE
Handle watch when running in editor preview or locally in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/watch-files-mixin.js
+++ b/src/watch-files-mixin.js
@@ -126,6 +126,13 @@ export const WatchFilesMixin = dedupingMixin( base => {
         return Promise.reject();
       }
 
+      // account for the component running in editor preview OR running locally in browser
+      if ( RisePlayerConfiguration.Helpers.isEditorPreview() || !RisePlayerConfiguration.Helpers.isInViewer()) {
+        // ensure files list is set for component file management usage
+        this._filesList = filesList.slice( 0 );
+        return Promise.reject();
+      }
+
       if ( !this._watchInitiated ) {
         this._watchType = this._getWatchType();
 

--- a/test/unit/watch-files-mixin.html
+++ b/test/unit/watch-files-mixin.html
@@ -37,7 +37,9 @@
     },
     Helpers: {
       useContentSentinel: () => false,
-      isDisplay: () => true
+      isDisplay: () => true,
+      isEditorPreview: () => false,
+      isInViewer: () => true
     },
     LocalMessaging: {
       isConnected: () => true
@@ -414,6 +416,21 @@
           assert.isFalse( watchFiles._watchInitiated );
 
           RisePlayerConfiguration.LocalMessaging.isConnected = () => { return true; }
+          done();
+        });
+      } );
+
+      test( "should reject if running in editor preview or locally in browser", (done) => {
+        const files = [ "a.jpg", "b.jpg" ];
+
+        RisePlayerConfiguration.Helpers.isEditorPreview = () => { return true; }
+
+        watchFiles.startWatch( files ).catch(() => {
+          assert.isFalse( watchFiles._watchInitiated );
+          // confirm files list is set
+          assert.deepEqual( watchFiles._filesList, [ "a.jpg", "b.jpg" ] );
+
+          RisePlayerConfiguration.Helpers.isEditorPreview = () => { return false; }
           done();
         });
       } );


### PR DESCRIPTION
## Description
Now check if component running in editor preview or locally in browser in `_startWatch()` function. Ensure to set `_filesList` if so and reject the promise. 

See changes in Image component to coincide with this change in this PR https://github.com/Rise-Vision/rise-image/pull/112

## Motivation and Context
Part of fix for issue https://github.com/Rise-Vision/rise-image/issues/109 . Other part was in PR #83 

## How Has This Been Tested?
Unit tests and via Image component. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
no
