### PR TITLE
Fix problem when error object may be used as Response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.10.5",
+  "version": "1.10.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-component",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "Common utilities for Rise Vision Web components used in Template pages",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/fetch-mixin.js
+++ b/src/fetch-mixin.js
@@ -72,7 +72,7 @@ export const FetchMixin = dedupingMixin( base => {
 
         this._processData( Object.assign( resp, { isCached: true }));
       }).catch(( cachedResp ) => {
-        cachedResp = cachedResp ? Object.assign( cachedResp, { isCached: true }) : null;
+        cachedResp = cachedResp instanceof Response ? Object.assign( cachedResp, { isCached: true }) : null;
 
         this._requestData( cachedResp );
       });

--- a/test/unit/fetch-mixin.html
+++ b/test/unit/fetch-mixin.html
@@ -157,6 +157,8 @@
           assert.isFalse( handleResponse.called );
 
           assert.isTrue( fetchMixin._requestData.called );
+          //confirm _requestData is called with null and not promise reject object returned by getCache()
+          assert.isTrue( fetchMixin._requestData.calledWith(null), "_requestData" );
 
           done();
         });


### PR DESCRIPTION
## Description
There is a case in the logic when [_tryGetCache](https://github.com/Rise-Vision/rise-common-component/blob/1b420851c583528974afb48739f90141a886606a/src/fetch-mixin.js#L70) may return rejected promise. The returned value is blindly used as a Response object, while it can be just an error. 

This situation was caught by [this unit test](https://github.com/Rise-Vision/rise-data-rss/blob/master/test/rise-data-rss-test.html#L518) in the rise-data-rss. This test was passing with the previous version of the rise-common-component because we did not make [this change](https://github.com/Rise-Vision/rise-common-component/commit/4b88ed22ecc017c41b36555e68156b44c2c4c85f#diff-66645fd9da3b636d2a8623c0457364de31fa77308cfa7123c1c915f90ecc6e50L75). In other words, before we were checking if returned object has the `clone` method which is an indirect way of checking if the object is an instance of the Response object.

Just as a side note. It's funny that the first commit in the [PR 82](https://github.com/Rise-Vision/rise-common-component/pull/82/commits) was checking for the `clone` method, but then we decided to improve logic and refactor the code and created the situation that we are now fixing in this PR.

## Motivation and Context
Error in the logic.


## How Has This Been Tested?
- Added assertion to the unit test that confirms the fix. If I remove the fix, the assertion fails. 
- Confirmed the fix with rise-data-rss.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
